### PR TITLE
feat: ecstasy_v1 leakage-free dimer benchmark + MSA Pairformer pipeline

### DIFF
--- a/configs/ecstasy_v1__msa_pairformer.yaml
+++ b/configs/ecstasy_v1__msa_pairformer.yaml
@@ -1,0 +1,14 @@
+# Stash for the per-model config that the ecstasy CLI would use to drive this
+# benchmark. Currently the pipeline runs through 09_run_msa_pairformer.py /
+# 10_score_msa_pairformer.py directly. When the existing adapter is updated to
+# read notebook-format complex a3ms (concatenated, no header), this config can
+# be promoted to ecstasy/configs/ecstasy_v1__msa_pairformer.yaml.
+benchmark: ecstasy_v1
+model: msa_pairformer
+data_root: /projects/u6jv/ecstasy
+env_path: ./envs/.venv-esmfold
+model_config:
+  complex_a3m_dir: /projects/u6jv/ecstasy/benchmarks/ecstasy_v1/msas
+  max_msa_depth: 512
+  weights_dir: /projects/u6jv/ecstasy/weights/msa_pairformer
+  hhfilter_bin: /home/u6jv/harsh.u6jv/ecstasy/tools/hhsuite/bin/hhfilter

--- a/scripts/build_ecstasy_v1/02_enumerate_dimers.py
+++ b/scripts/build_ecstasy_v1/02_enumerate_dimers.py
@@ -1,0 +1,286 @@
+"""Enumerate candidate dimers from Boltz-2 validation_ids_v2.txt.
+
+For each PDB ID:
+  1. Pull bio-assembly 1 mmCIF from RCSB.
+  2. Parse chains, drop non-amino-acid atoms.
+  3. Enumerate every chain pair with backbone-atom contact <= 10 A.
+  4. Apply quality filters (X-ray, resolution <= 3.5 A, min chain >= 40 res).
+  5. Apply size filter (total length <= 1200 residues per dimer).
+  6. Dump per-chain PDB files into <out>/candidates/chains/.
+  7. Write candidates/dimers.parquet with interface metadata.
+
+Also queries RCSB GraphQL for per-PDB metadata (deposit date, resolution,
+method) and writes candidates/val_v2_metadata.parquet.
+"""
+
+from __future__ import annotations
+
+import json
+import multiprocessing as mp
+import sys
+import traceback
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import pandas as pd
+
+# Import the shared utilities. We add the script dir to sys.path so this can be
+# run from anywhere (e.g. via `python scripts/build_ecstasy_v1/02_...`).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from common import (  # noqa: E402
+    download_cif_assembly,
+    enumerate_dimer_pairs,
+    interface_residue_indices,
+    parse_cif_bytes,
+    select_chain_atoms,
+    split_into_chains,
+    write_chain_pdb,
+)
+
+VAL_V2_PATH = Path(
+    "/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/candidates/validation_ids_v2.txt"
+)
+OUT_ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/candidates")
+CHAINS_DIR = OUT_ROOT / "chains"
+META_PATH = OUT_ROOT / "val_v2_metadata.parquet"
+DIMERS_PATH = OUT_ROOT / "dimers.parquet"
+PER_ENTRY_LOG = OUT_ROOT / "per_entry_log.parquet"
+
+MIN_CHAIN_LEN = 40
+MAX_DIMER_LEN = 1200
+MIN_CONTACTS = 3
+ASSEMBLY_ID = 1
+
+
+def fetch_rcsb_metadata(pdb_ids: list[str]) -> pd.DataFrame:
+    """Batch-query RCSB GraphQL for deposit_date / release_date / resolution / method."""
+    BATCH = 50
+    rows: list[dict] = []
+    for i in range(0, len(pdb_ids), BATCH):
+        batch = pdb_ids[i : i + BATCH]
+        ids_str = '","'.join(batch)
+        query = (
+            '{ entries(entry_ids: ["' + ids_str + '"]) {'
+            " rcsb_id"
+            " rcsb_accession_info { deposit_date initial_release_date }"
+            " exptl { method }"
+            " rcsb_entry_info { resolution_combined polymer_entity_count_protein }"
+            " } }"
+        )
+        req = Request(
+            "https://data.rcsb.org/graphql",
+            data=json.dumps({"query": query}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        with urlopen(req, timeout=60) as r:
+            data = json.load(r)
+        for e in data["data"]["entries"] or []:
+            if e is None:
+                continue
+            method = (e.get("exptl") or [{}])[0].get("method") if e.get("exptl") else None
+            res_list = (e.get("rcsb_entry_info") or {}).get(
+                "resolution_combined"
+            ) or []
+            resolution = res_list[0] if res_list else None
+            n_prot = (e.get("rcsb_entry_info") or {}).get(
+                "polymer_entity_count_protein"
+            )
+            ai = e["rcsb_accession_info"] or {}
+            rows.append(
+                {
+                    "pdb_id": e["rcsb_id"].lower(),
+                    "deposit_date": (ai.get("deposit_date") or "")[:10],
+                    "release_date": (ai.get("initial_release_date") or "")[:10],
+                    "method": method,
+                    "resolution": resolution,
+                    "n_protein_entities": n_prot,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def passes_quality(meta_row: pd.Series) -> tuple[bool, str]:
+    """Return (passes, reason_if_not)."""
+    if meta_row["method"] not in ("X-RAY DIFFRACTION",):
+        return False, f"method={meta_row['method']}"
+    if meta_row["resolution"] is None or meta_row["resolution"] > 3.5:
+        return False, f"resolution={meta_row['resolution']}"
+    return True, ""
+
+
+def process_one(args: tuple[str, dict]) -> dict:
+    """Worker: download + enumerate dimers for a single PDB ID."""
+    pdb_id, meta = args
+    pdb_id = pdb_id.lower()
+    out: dict = {
+        "pdb_id": pdb_id,
+        "status": "ok",
+        "n_chains": 0,
+        "n_dimers": 0,
+        "dimer_rows": [],
+        "chain_writes": [],  # list of (chain_id, out_path, sequence)
+        "error": None,
+    }
+    try:
+        cif_bytes = download_cif_assembly(pdb_id, ASSEMBLY_ID)
+        atoms = parse_cif_bytes(cif_bytes)
+        chains = split_into_chains(atoms)
+        out["n_chains"] = len(chains)
+        if len(chains) < 2:
+            out["status"] = "skip_too_few_chains"
+            return out
+
+        # short-chain filter applied per-chain before enumerating pairs
+        short_idxs = {i for i, c in enumerate(chains) if len(c.res_ids) < MIN_CHAIN_LEN}
+
+        for i, j in enumerate_dimer_pairs(chains):
+            if i in short_idxs or j in short_idxs:
+                continue
+            c_a, c_b = chains[i], chains[j]
+            total_len = len(c_a.res_ids) + len(c_b.res_ids)
+            if total_len > MAX_DIMER_LEN:
+                continue
+            ia, ib, npair = interface_residue_indices(c_a, c_b)
+            if npair < MIN_CONTACTS:
+                continue
+            out["dimer_rows"].append(
+                {
+                    "pdb_id": pdb_id,
+                    "assembly_id": ASSEMBLY_ID,
+                    "chain_a": c_a.chain_id,
+                    "chain_b": c_b.chain_id,
+                    "len_a": int(len(c_a.res_ids)),
+                    "len_b": int(len(c_b.res_ids)),
+                    "seq_a": c_a.sequence,
+                    "seq_b": c_b.sequence,
+                    "interface_idx_a": ia.tolist(),
+                    "interface_idx_b": ib.tolist(),
+                    "n_interface_residues_a": int(len(ia)),
+                    "n_interface_residues_b": int(len(ib)),
+                    "n_contact_pairs": int(npair),
+                    "is_homodimer": bool(c_a.sequence == c_b.sequence),
+                }
+            )
+
+        # determine which chains we actually need to dump (those appearing in a kept dimer)
+        kept_chain_ids = {r["chain_a"] for r in out["dimer_rows"]} | {
+            r["chain_b"] for r in out["dimer_rows"]
+        }
+        for c in chains:
+            if c.chain_id not in kept_chain_ids:
+                continue
+            chain_atoms = select_chain_atoms(atoms, c.chain_id)
+            chain_path = CHAINS_DIR / f"{pdb_id}_{ASSEMBLY_ID}_{c.chain_id}.pdb"
+            write_chain_pdb(chain_atoms, chain_path)
+            out["chain_writes"].append(
+                {
+                    "pdb_id": pdb_id,
+                    "chain_id": c.chain_id,
+                    "path": str(chain_path),
+                    "length": int(len(c.res_ids)),
+                    "sequence": c.sequence,
+                }
+            )
+
+        out["n_dimers"] = len(out["dimer_rows"])
+    except HTTPError as e:
+        out["status"] = "http_error"
+        out["error"] = f"{e.code} {e.reason}"
+    except URLError as e:
+        out["status"] = "url_error"
+        out["error"] = str(e.reason)
+    except Exception as e:  # noqa: BLE001
+        out["status"] = "parse_error"
+        out["error"] = f"{type(e).__name__}: {e}\n{traceback.format_exc(limit=2)}"
+    return out
+
+
+def main() -> int:
+    CHAINS_DIR.mkdir(parents=True, exist_ok=True)
+
+    pdb_ids = [
+        ln.strip().lower()
+        for ln in VAL_V2_PATH.read_text().splitlines()
+        if ln.strip()
+    ]
+    print(f"Loaded {len(pdb_ids)} PDB IDs from {VAL_V2_PATH}")
+
+    print("Querying RCSB metadata...")
+    meta_df = fetch_rcsb_metadata(pdb_ids)
+    meta_df.to_parquet(META_PATH, index=False)
+    print(f"  wrote {META_PATH}  ({len(meta_df)} rows)")
+
+    # apply quality filter at the PDB-entry level
+    keep_mask = meta_df.apply(
+        lambda r: passes_quality(r)[0], axis=1
+    )
+    kept_ids = meta_df.loc[keep_mask, "pdb_id"].tolist()
+    rejected_n = len(meta_df) - len(kept_ids)
+    print(
+        f"  quality filter: kept {len(kept_ids)}/{len(meta_df)} "
+        f"({rejected_n} rejected by X-ray/resolution)"
+    )
+
+    meta_by_id = {r["pdb_id"]: r.to_dict() for _, r in meta_df.iterrows()}
+
+    print(f"Enumerating dimers for {len(kept_ids)} PDB IDs (parallel)...")
+    all_dimers: list[dict] = []
+    all_chains: list[dict] = []
+    per_entry: list[dict] = []
+    nworkers = min(16, mp.cpu_count())
+    with ProcessPoolExecutor(max_workers=nworkers) as pool:
+        futures = {
+            pool.submit(process_one, (pid, meta_by_id[pid])): pid for pid in kept_ids
+        }
+        for n, fut in enumerate(as_completed(futures), 1):
+            res = fut.result()
+            all_dimers.extend(res["dimer_rows"])
+            all_chains.extend(res["chain_writes"])
+            per_entry.append(
+                {
+                    "pdb_id": res["pdb_id"],
+                    "status": res["status"],
+                    "n_chains": res["n_chains"],
+                    "n_dimers": res["n_dimers"],
+                    "error": res["error"],
+                }
+            )
+            if n % 50 == 0 or n == len(futures):
+                ok = sum(1 for p in per_entry if p["status"] == "ok")
+                ndim = sum(p["n_dimers"] for p in per_entry)
+                print(f"  [{n}/{len(futures)}]  ok={ok}  total_dimers={ndim}")
+
+    dimers_df = pd.DataFrame(all_dimers)
+    chains_df = pd.DataFrame(all_chains)
+    per_entry_df = pd.DataFrame(per_entry)
+    dimers_df.to_parquet(DIMERS_PATH, index=False)
+    chains_df.to_parquet(OUT_ROOT / "chains_manifest.parquet", index=False)
+    per_entry_df.to_parquet(PER_ENTRY_LOG, index=False)
+
+    print()
+    print(f"  wrote {DIMERS_PATH}            ({len(dimers_df)} dimers)")
+    print(f"  wrote chains_manifest.parquet  ({len(chains_df)} chain PDBs)")
+    print(f"  wrote {PER_ENTRY_LOG}          (per-PDB processing log)")
+    print()
+    print("=== summary ===")
+    print(f"PDB IDs queried:          {len(pdb_ids)}")
+    print(f"  rejected by quality:    {rejected_n}")
+    print(f"  processed:              {len(kept_ids)}")
+    print(f"  status counts:          {per_entry_df['status'].value_counts().to_dict()}")
+    print(f"Dimers (post-filter):     {len(dimers_df)}")
+    if len(dimers_df):
+        print(
+            f"  homodimers:             {int(dimers_df['is_homodimer'].sum())} "
+            f"({100 * dimers_df['is_homodimer'].mean():.1f}%)"
+        )
+        print(
+            f"  total residues range:   [{(dimers_df['len_a'] + dimers_df['len_b']).min()}, "
+            f"{(dimers_df['len_a'] + dimers_df['len_b']).max()}]"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v1/03_extract_train_chains.py
+++ b/scripts/build_ecstasy_v1/03_extract_train_chains.py
@@ -1,0 +1,159 @@
+"""Extract per-chain PDB files from MINT-train PDB CIFs for the Foldseek DB.
+
+MINT-softnano's train split (PDB <= 2021-09-30) has 25,682 dimer entries.
+CIFs live at /projects/u6jv/public/MINT/DATA/pdb/raw/cif_unzipped/<bucket>/<id>.cif
+where <bucket> is a numeric hash bucket (000-...). We build a one-time
+filename index, then for each train entry load the CIF and dump every
+distinct protein chain as a PDB file.
+
+Dedup is done after the fact by sequence (one Foldseek DB row per unique
+chain sequence) to keep the search DB smaller. We still write all chain
+PDB files because dumping is cheap and parallel.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import sys
+import traceback
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from common import (  # noqa: E402
+    load_local_cif,
+    select_chain_atoms,
+    split_into_chains,
+    write_chain_pdb,
+)
+
+MINT_SPLIT_PARQUET = Path(
+    "/projects/u6jv/public/MINT/DATA/pdb/processed/splits/seq_id_30/index.parquet"
+)
+MINT_CIF_ROOT = Path("/projects/u6jv/public/MINT/DATA/pdb/raw/cif_unzipped")
+OUT_ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/train_db")
+CHAINS_DIR = OUT_ROOT / "mint_train_chains"
+INDEX_PATH = OUT_ROOT / "mint_train_chains_manifest.parquet"
+MISSING_PATH = OUT_ROOT / "mint_train_missing.parquet"
+
+MIN_CHAIN_LEN = 40
+DATE_CUTOFF = "2021-09-30"  # MINT-softnano train cutoff
+
+
+def build_cif_index() -> dict[str, Path]:
+    """Scan MINT cif_unzipped/ once to map pdb_id -> CIF path."""
+    print(f"Building CIF index under {MINT_CIF_ROOT} ...")
+    idx: dict[str, Path] = {}
+    for bucket in sorted(MINT_CIF_ROOT.iterdir()):
+        if not bucket.is_dir():
+            continue
+        for cif in bucket.glob("*.cif"):
+            idx[cif.stem.lower()] = cif
+    print(f"  indexed {len(idx)} CIFs")
+    return idx
+
+
+def process_one(args: tuple[str, str]) -> dict:
+    """Worker: load CIF for one MINT-train entry, dump per-chain PDBs."""
+    pdb_id, cif_path_s = args
+    cif_path = Path(cif_path_s)
+    out: dict = {
+        "pdb_id": pdb_id,
+        "status": "ok",
+        "n_chains_written": 0,
+        "chains": [],  # list of (chain_id, path, length, sequence)
+        "error": None,
+    }
+    try:
+        atoms = load_local_cif(cif_path)
+        chains = split_into_chains(atoms)
+        for c in chains:
+            if len(c.res_ids) < MIN_CHAIN_LEN:
+                continue
+            chain_atoms = select_chain_atoms(atoms, c.chain_id)
+            chain_path = CHAINS_DIR / f"{pdb_id}_{c.chain_id}.pdb"
+            write_chain_pdb(chain_atoms, chain_path)
+            out["chains"].append(
+                {
+                    "pdb_id": pdb_id,
+                    "chain_id": c.chain_id,
+                    "path": str(chain_path),
+                    "length": int(len(c.res_ids)),
+                    "sequence": c.sequence,
+                }
+            )
+        out["n_chains_written"] = len(out["chains"])
+        if out["n_chains_written"] == 0:
+            out["status"] = "skip_no_long_chains"
+    except Exception as e:  # noqa: BLE001
+        out["status"] = "parse_error"
+        out["error"] = f"{type(e).__name__}: {e}\n{traceback.format_exc(limit=2)}"
+    return out
+
+
+def main() -> int:
+    CHAINS_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Train ID list (de-duplicated)
+    split_df = pd.read_parquet(MINT_SPLIT_PARQUET)
+    train_ids = sorted(split_df.loc[split_df["split"] == "train", "id"].unique().tolist())
+    train_ids = [pid.lower() for pid in train_ids]
+    print(f"MINT-train PDB IDs (seq_id_30): {len(train_ids)}")
+
+    # CIF filename index (one-time scan)
+    cif_idx = build_cif_index()
+
+    # Match train IDs to CIF paths
+    matched = []
+    missing = []
+    for pid in train_ids:
+        p = cif_idx.get(pid)
+        if p is None:
+            missing.append(pid)
+        else:
+            matched.append((pid, str(p)))
+    print(f"  matched to CIFs: {len(matched)}  missing: {len(missing)}")
+    if missing:
+        pd.DataFrame({"pdb_id": missing}).to_parquet(MISSING_PATH, index=False)
+        print(f"  wrote missing list to {MISSING_PATH}")
+
+    print(f"Extracting chains (parallel) ...")
+    all_chains: list[dict] = []
+    statuses: list[dict] = []
+    nworkers = min(32, mp.cpu_count())
+    with ProcessPoolExecutor(max_workers=nworkers) as pool:
+        futures = {pool.submit(process_one, m): m[0] for m in matched}
+        for n, fut in enumerate(as_completed(futures), 1):
+            res = fut.result()
+            all_chains.extend(res["chains"])
+            statuses.append(
+                {
+                    "pdb_id": res["pdb_id"],
+                    "status": res["status"],
+                    "n_chains": res["n_chains_written"],
+                    "error": res["error"],
+                }
+            )
+            if n % 1000 == 0 or n == len(futures):
+                ok = sum(1 for s in statuses if s["status"] == "ok")
+                nch = sum(s["n_chains"] for s in statuses)
+                print(f"  [{n}/{len(futures)}]  ok={ok}  chains_written={nch}")
+
+    chains_df = pd.DataFrame(all_chains)
+    status_df = pd.DataFrame(statuses)
+    chains_df.to_parquet(INDEX_PATH, index=False)
+    status_df.to_parquet(OUT_ROOT / "mint_train_per_entry_log.parquet", index=False)
+
+    print()
+    print(f"  wrote {INDEX_PATH}  ({len(chains_df)} chain PDBs)")
+    # Sequence-dedup statistic for the planning step
+    n_unique_seqs = chains_df["sequence"].nunique()
+    print(f"  unique chain sequences: {n_unique_seqs}")
+    print(f"  status: {status_df['status'].value_counts().to_dict()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v1/04_run_foldseek.py
+++ b/scripts/build_ecstasy_v1/04_run_foldseek.py
@@ -1,0 +1,95 @@
+"""Run Foldseek easy-search: candidate chains vs MINT-train chains.
+
+Uses --threads from SLURM_CPUS_PER_TASK if available (else 16).
+Output format: query target lddt qstart qend qlen tstart tend tlen alnlen evalue
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+FOLDSEEK = Path("/home/u6jv/harsh.u6jv/ecstasy/tools/foldseek/bin/foldseek")
+CANDIDATES_DIR = Path(
+    "/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/candidates/chains"
+)
+TRAIN_DIR = Path(
+    "/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/train_db/mint_train_chains"
+)
+OUT_ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1")
+DB_DIR = OUT_ROOT / "foldseek_dbs"
+TMP_DIR = OUT_ROOT / "foldseek_tmp"
+HITS_PATH = OUT_ROOT / "foldseek_hits.m8"
+
+FORMAT_OUTPUT = "query,target,lddt,qstart,qend,qlen,tstart,tend,tlen,alnlen,evalue"
+
+NTHREADS = int(
+    os.environ.get("SLURM_CPUS_PER_TASK")
+    or os.environ.get("OMP_NUM_THREADS")
+    or 16
+)
+
+
+def run(cmd: list[str]) -> None:
+    print(" $ " + " ".join(str(c) for c in cmd), flush=True)
+    subprocess.run(cmd, check=True)
+
+
+def main() -> int:
+    DB_DIR.mkdir(parents=True, exist_ok=True)
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
+
+    cand_count = len(list(CANDIDATES_DIR.glob("*.pdb")))
+    train_count = len(list(TRAIN_DIR.glob("*.pdb")))
+    print(f"Candidate chain PDBs: {cand_count}")
+    print(f"MINT-train chain PDBs: {train_count}")
+    print(f"Threads:               {NTHREADS}")
+    if cand_count == 0 or train_count == 0:
+        print("ERROR: empty input dir", file=sys.stderr)
+        return 1
+
+    cand_db = DB_DIR / "candidates_db"
+    train_db = DB_DIR / "mint_train_db"
+
+    if not (DB_DIR / "candidates_db").exists():
+        run([str(FOLDSEEK), "createdb", str(CANDIDATES_DIR), str(cand_db),
+             "--threads", str(NTHREADS)])
+    else:
+        print(f"  reusing existing candidates DB at {cand_db}")
+    if not (DB_DIR / "mint_train_db").exists():
+        run([str(FOLDSEEK), "createdb", str(TRAIN_DIR), str(train_db),
+             "--threads", str(NTHREADS)])
+    else:
+        print(f"  reusing existing MINT-train DB at {train_db}")
+
+    if TMP_DIR.exists():
+        shutil.rmtree(TMP_DIR)
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
+
+    run([
+        str(FOLDSEEK),
+        "easy-search",
+        str(CANDIDATES_DIR),
+        str(train_db),
+        str(HITS_PATH),
+        str(TMP_DIR),
+        "-s", "11.0",
+        "-e", "0.05",
+        "--alignment-type", "2",
+        "--max-seqs", "1000",
+        "--threads", str(NTHREADS),
+        "--format-output", FORMAT_OUTPUT,
+    ])
+
+    print(f"\n  wrote {HITS_PATH}  ({HITS_PATH.stat().st_size / 1e6:.1f} MB)")
+    with HITS_PATH.open() as f:
+        n_hits = sum(1 for _ in f)
+    print(f"  {n_hits} hit rows")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v1/05_compute_interface_edges.py
+++ b/scripts/build_ecstasy_v1/05_compute_interface_edges.py
@@ -1,0 +1,137 @@
+"""Compute Pinder-style interface-coverage edges from Foldseek hits.
+
+For each Foldseek hit (candidate_chain, mint_train_chain):
+  - look up the candidate chain's interface residues from dimers.parquet
+  - coverage = |I_candidate ∩ [qstart..qend]| / |I_candidate|
+  - keep the hit if coverage >= 0.5 (Pinder GraphConfig default)
+
+A candidate chain can appear in multiple dimers (if its PDB ID had >2 chains
+in bio-assembly 1 and so it contributed to >1 contacting pair). The interface
+residue set differs per partner, so we expand each hit into one row per
+(candidate dimer, candidate chain) and recompute coverage with the right
+interface set.
+
+Output: interface_edges.parquet with one row per kept edge.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+CANDIDATES_DIR = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/candidates")
+HITS_PATH = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/foldseek_hits.m8")
+OUT_PATH = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/interface_edges.parquet")
+ALL_EDGES_PATH = Path(
+    "/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/all_edges_with_coverage.parquet"
+)
+
+COVERAGE_THRESHOLD = 0.5  # Pinder GraphConfig default
+
+
+def _strip_ext(name: str) -> str:
+    if name.endswith(".pdb"):
+        return name[:-4]
+    return name
+
+
+def main() -> int:
+    print(f"Loading Foldseek hits from {HITS_PATH} ...")
+    cols = [
+        "query", "target", "lddt",
+        "qstart", "qend", "qlen",
+        "tstart", "tend", "tlen",
+        "alnlen", "evalue",
+    ]
+    hits = pd.read_csv(HITS_PATH, sep="\t", header=None, names=cols)
+    hits["query"] = hits["query"].map(_strip_ext)
+    hits["target"] = hits["target"].map(_strip_ext)
+    print(f"  {len(hits)} raw hits")
+    hits = hits[hits["query"] != hits["target"]].reset_index(drop=True)
+    print(f"  {len(hits)} hits after dropping any accidental self-hits")
+
+    print(f"Loading candidate dimers from {CANDIDATES_DIR}/dimers.parquet ...")
+    dimers = pd.read_parquet(CANDIDATES_DIR / "dimers.parquet")
+    print(f"  {len(dimers)} candidate dimers")
+
+    cand_long: list[dict] = []
+    for di, d in dimers.iterrows():
+        key_a = f"{d['pdb_id']}_{d['assembly_id']}_{d['chain_a']}"
+        key_b = f"{d['pdb_id']}_{d['assembly_id']}_{d['chain_b']}"
+        cand_long.append(
+            {
+                "dimer_idx": di,
+                "pdb_id": d["pdb_id"],
+                "chain_label": d["chain_a"],
+                "partner_label": d["chain_b"],
+                "side": "a",
+                "query_key": key_a,
+                "interface_idx": np.array(d["interface_idx_a"], dtype=np.int32),
+                "n_interface": int(d["n_interface_residues_a"]),
+                "chain_len": int(d["len_a"]),
+                "is_homodimer": bool(d["is_homodimer"]),
+            }
+        )
+        cand_long.append(
+            {
+                "dimer_idx": di,
+                "pdb_id": d["pdb_id"],
+                "chain_label": d["chain_b"],
+                "partner_label": d["chain_a"],
+                "side": "b",
+                "query_key": key_b,
+                "interface_idx": np.array(d["interface_idx_b"], dtype=np.int32),
+                "n_interface": int(d["n_interface_residues_b"]),
+                "chain_len": int(d["len_b"]),
+                "is_homodimer": bool(d["is_homodimer"]),
+            }
+        )
+    cand_long_df = pd.DataFrame(cand_long)
+    print(f"  expanded to {len(cand_long_df)} (dimer, chain-side) rows")
+
+    print("Joining + computing coverage ...")
+    merged = hits.merge(
+        cand_long_df, left_on="query", right_on="query_key", how="inner"
+    )
+    print(f"  {len(merged)} (hit, candidate-side) rows after join")
+
+    def _coverage_row(row) -> float:
+        iface = row["interface_idx"]
+        if len(iface) == 0:
+            return 0.0
+        qs, qe = int(row["qstart"]), int(row["qend"])
+        in_range = (iface >= qs - 1) & (iface <= qe - 1)
+        return float(in_range.sum()) / float(len(iface))
+
+    merged["coverage"] = merged.apply(_coverage_row, axis=1)
+
+    keep_cols = [
+        "dimer_idx", "pdb_id", "chain_label", "partner_label", "side",
+        "query_key", "target", "lddt", "qstart", "qend", "qlen",
+        "tstart", "tend", "tlen", "alnlen", "evalue",
+        "n_interface", "chain_len", "is_homodimer", "coverage",
+    ]
+    full = merged[keep_cols].copy()
+    full.to_parquet(ALL_EDGES_PATH, index=False)
+    print(f"  wrote {ALL_EDGES_PATH}  ({len(full)} rows)")
+
+    kept = full[full["coverage"] >= COVERAGE_THRESHOLD].copy()
+    kept.to_parquet(OUT_PATH, index=False)
+    print(f"  wrote {OUT_PATH}  ({len(kept)} rows above coverage {COVERAGE_THRESHOLD})")
+
+    print()
+    print("=== summary ===")
+    print(f"raw hits:                    {len(hits)}")
+    print(f"hits joined to candidates:   {len(merged)}")
+    print(f"with coverage >= {COVERAGE_THRESHOLD}:        {len(kept)}")
+    if len(kept):
+        print(f"LDDT distribution of kept edges:")
+        print(kept["lddt"].describe().to_string())
+        print(f"unique candidate dimers w/ >=1 kept edge: {kept['dimer_idx'].nunique()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v1/06_deleak_report.py
+++ b/scripts/build_ecstasy_v1/06_deleak_report.py
@@ -1,0 +1,266 @@
+"""Generate the ecstasy_v1 leakage analysis report.
+
+Inputs:
+  - candidates/dimers.parquet            (319 candidate dimers)
+  - all_edges_with_coverage.parquet      (every Foldseek hit with computed
+                                          interface coverage, no threshold yet)
+
+Outputs:
+  - deleak_report.md         (numbers + threshold sweep)
+  - deleak_report.png        (4-panel figure)
+  - per_dimer_leakage.parquet (one row per dimer: leakage stats)
+
+The "drop count" sweep simulates Pinder Level-2: a dimer is dropped if
+*either* of its two chains has any Foldseek hit to a MINT-train chain that
+passes both the coverage and LDDT thresholds.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1")
+DIMERS_PATH = ROOT / "candidates" / "dimers.parquet"
+ALL_EDGES_PATH = ROOT / "all_edges_with_coverage.parquet"
+REPORT_MD = ROOT / "deleak_report.md"
+REPORT_PNG = ROOT / "deleak_report.png"
+PER_DIMER_PATH = ROOT / "per_dimer_leakage.parquet"
+
+LDDT_GRID = [0.5, 0.6, 0.7, 0.8, 0.9]
+COVERAGE_GRID = [0.3, 0.5, 0.7]
+
+
+def main() -> int:
+    dimers = pd.read_parquet(DIMERS_PATH)
+    edges = pd.read_parquet(ALL_EDGES_PATH)
+    print(f"Loaded {len(dimers)} dimers, {len(edges)} edges (any coverage)")
+
+    # Per-dimer leakage summary
+    per_dimer = []
+    for di, d in dimers.iterrows():
+        e = edges[edges["dimer_idx"] == di]
+        # split by side
+        e_a = e[e["side"] == "a"]
+        e_b = e[e["side"] == "b"]
+        per_dimer.append(
+            {
+                "dimer_idx": di,
+                "pdb_id": d["pdb_id"],
+                "chain_a": d["chain_a"],
+                "chain_b": d["chain_b"],
+                "len_a": d["len_a"],
+                "len_b": d["len_b"],
+                "is_homodimer": d["is_homodimer"],
+                "n_hits_a": len(e_a),
+                "n_hits_b": len(e_b),
+                "n_hits_a_cov50": int((e_a["coverage"] >= 0.5).sum()),
+                "n_hits_b_cov50": int((e_b["coverage"] >= 0.5).sum()),
+                "max_lddt_a_cov50": (
+                    float(e_a.loc[e_a["coverage"] >= 0.5, "lddt"].max())
+                    if (e_a["coverage"] >= 0.5).any()
+                    else 0.0
+                ),
+                "max_lddt_b_cov50": (
+                    float(e_b.loc[e_b["coverage"] >= 0.5, "lddt"].max())
+                    if (e_b["coverage"] >= 0.5).any()
+                    else 0.0
+                ),
+            }
+        )
+    per_dimer_df = pd.DataFrame(per_dimer)
+    per_dimer_df.to_parquet(PER_DIMER_PATH, index=False)
+    print(f"  wrote {PER_DIMER_PATH}")
+
+    # Threshold-sweep drop matrix (Level-2: either chain triggers => drop)
+    sweep_rows = []
+    for lddt_th in LDDT_GRID:
+        for cov_th in COVERAGE_GRID:
+            mask = (edges["coverage"] >= cov_th) & (edges["lddt"] >= lddt_th)
+            leaky_dimers = set(edges.loc[mask, "dimer_idx"].unique())
+            n_drop = len(leaky_dimers)
+            n_keep = len(dimers) - n_drop
+            # subsplits
+            homo_drop = sum(
+                1 for di in leaky_dimers if dimers.iloc[di]["is_homodimer"]
+            )
+            sweep_rows.append(
+                {
+                    "lddt_th": lddt_th,
+                    "cov_th": cov_th,
+                    "n_dropped": n_drop,
+                    "n_kept": n_keep,
+                    "n_dropped_homo": homo_drop,
+                    "n_dropped_hetero": n_drop - homo_drop,
+                }
+            )
+    sweep = pd.DataFrame(sweep_rows)
+
+    # === figure ===
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, axes = plt.subplots(2, 2, figsize=(13, 9))
+
+    # (a) Per-dimer max LDDT histogram, at coverage>=0.5
+    ax = axes[0, 0]
+    max_lddt_per_dimer = np.maximum(
+        per_dimer_df["max_lddt_a_cov50"], per_dimer_df["max_lddt_b_cov50"]
+    )
+    ax.hist(max_lddt_per_dimer, bins=40, edgecolor="black", color="steelblue")
+    ax.set_xlabel("max LDDT to any MINT-train chain (coverage ≥ 0.5)")
+    ax.set_ylabel("# candidate dimers")
+    ax.set_title("Per-dimer max LDDT (Level-2 leak signal)")
+    ax.axvline(0.7, color="red", linestyle="--", label="Pinder LDDT 0.7 cutoff")
+    ax.legend()
+
+    # (b) #hits per chain (cov >= 0.5) CDF — how many MINT-train chains overlap
+    ax = axes[0, 1]
+    n_hits_per_chain = pd.concat(
+        [per_dimer_df["n_hits_a_cov50"], per_dimer_df["n_hits_b_cov50"]]
+    )
+    sorted_hits = np.sort(n_hits_per_chain)
+    cdf = np.arange(1, len(sorted_hits) + 1) / len(sorted_hits)
+    ax.semilogx(np.maximum(sorted_hits, 0.5), cdf, color="darkorange")
+    ax.set_xlabel("# MINT-train chains with cov ≥ 0.5 (per candidate chain)")
+    ax.set_ylabel("CDF over candidate chains")
+    ax.set_title("Neighborhood density: chain-level coverage hits")
+    ax.grid(True, alpha=0.3)
+
+    # (c) Drop count vs LDDT for cov=0.5
+    ax = axes[1, 0]
+    for cov_th, color in zip([0.3, 0.5, 0.7], ["#1f77b4", "#ff7f0e", "#2ca02c"]):
+        sub = sweep[sweep["cov_th"] == cov_th].sort_values("lddt_th")
+        ax.plot(
+            sub["lddt_th"],
+            sub["n_dropped"],
+            marker="o",
+            color=color,
+            label=f"cov ≥ {cov_th}",
+        )
+    ax.set_xlabel("LDDT threshold")
+    ax.set_ylabel("# candidate dimers dropped (Level-2)")
+    ax.set_title(f"Drop-count sweep (out of {len(dimers)} candidates)")
+    ax.legend()
+    ax.grid(True, alpha=0.3)
+
+    # (d) homo vs hetero breakdown at default (cov=0.5, lddt=0.7)
+    ax = axes[1, 1]
+    n_homo = int(dimers["is_homodimer"].sum())
+    n_het = len(dimers) - n_homo
+    default = sweep[(sweep["cov_th"] == 0.5) & (sweep["lddt_th"] == 0.7)].iloc[0]
+    bars = ax.bar(
+        ["homo", "hetero"],
+        [n_homo, n_het],
+        color=["#888888", "#888888"],
+        label="total",
+    )
+    ax.bar(
+        ["homo", "hetero"],
+        [int(default["n_dropped_homo"]), int(default["n_dropped_hetero"])],
+        color=["red", "red"],
+        alpha=0.7,
+        label="dropped @ cov≥0.5, LDDT≥0.7",
+    )
+    ax.set_ylabel("# dimers")
+    ax.set_title("Homo vs hetero leakage (Pinder defaults)")
+    ax.legend()
+    for i, b in enumerate(bars):
+        n_drop_i = int(default["n_dropped_homo"]) if i == 0 else int(default["n_dropped_hetero"])
+        n_tot_i = n_homo if i == 0 else n_het
+        ax.text(
+            b.get_x() + b.get_width() / 2,
+            b.get_height() + 2,
+            f"{n_drop_i}/{n_tot_i} drop",
+            ha="center",
+            fontsize=10,
+        )
+
+    fig.suptitle(
+        f"ecstasy_v1 leakage analysis — {len(dimers)} candidate dimers vs MINT-train",
+        fontsize=14,
+        fontweight="bold",
+    )
+    fig.tight_layout()
+    fig.savefig(REPORT_PNG, dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    print(f"  wrote {REPORT_PNG}")
+
+    # === markdown report ===
+    n_dimers = len(dimers)
+    n_homo = int(dimers["is_homodimer"].sum())
+    n_het = n_dimers - n_homo
+    default_row = sweep[(sweep["cov_th"] == 0.5) & (sweep["lddt_th"] == 0.7)].iloc[0]
+    sweep_table = sweep.pivot(
+        index="lddt_th", columns="cov_th", values="n_dropped"
+    ).round(0).astype(int)
+
+    md = []
+    md.append("# ecstasy_v1 leakage analysis report")
+    md.append("")
+    md.append(
+        "Candidate pool: dimers enumerated from Boltz-2 `validation_ids_v2.txt` "
+        "(bio-assembly 1, all chain pairs ≤ 10 Å backbone contact, X-ray ≤ 3.5 Å, "
+        "min chain ≥ 40 res, total ≤ 1200 res).\n"
+    )
+    md.append("Leak target: MINT-softnano train chains (PDB ≤ 2021-09-30, seq_id_30 split).\n")
+    md.append("Method: Foldseek `easy-search --alignment-type 2 -s 11.0 -e 0.05`, then "
+              "per-hit interface coverage = |I_candidate ∩ [qstart..qend]| / |I_candidate|. "
+              "Level-2 drop rule: a dimer is dropped if *either* chain has any qualifying hit.\n")
+    md.append("")
+    md.append(f"## Candidate pool")
+    md.append(f"- Total candidate dimers: **{n_dimers}**")
+    md.append(f"  - homodimers: {n_homo}  ({100*n_homo/n_dimers:.1f}%)")
+    md.append(f"  - heterodimers: {n_het}  ({100*n_het/n_dimers:.1f}%)")
+    md.append(f"- Total length range: "
+              f"[{(dimers['len_a']+dimers['len_b']).min()}, "
+              f"{(dimers['len_a']+dimers['len_b']).max()}] residues")
+    md.append("")
+    md.append("## Threshold sweep — # candidates dropped under Level-2 rule")
+    md.append("")
+    md.append("Rows = LDDT threshold; columns = coverage threshold. "
+              f"Value = # candidate dimers ({n_dimers} total) whose either chain has "
+              "at least one MINT-train Foldseek hit passing both thresholds → dropped.")
+    md.append("")
+    md.append("| LDDT \\ cov | " + " | ".join(f"≥{c}" for c in COVERAGE_GRID) + " |")
+    md.append("|---" + "|---" * len(COVERAGE_GRID) + "|")
+    for lddt_th in LDDT_GRID:
+        row = [f"≥{lddt_th}"]
+        for cov_th in COVERAGE_GRID:
+            v = int(sweep_table.loc[lddt_th, cov_th])
+            row.append(f"{v} ({100*v/n_dimers:.0f}%)")
+        md.append("| " + " | ".join(row) + " |")
+    md.append("")
+    md.append(f"## At Pinder defaults (cov ≥ 0.5, LDDT ≥ 0.7)")
+    md.append(f"- dropped: **{int(default_row['n_dropped'])}** of {n_dimers}  "
+              f"({100*default_row['n_dropped']/n_dimers:.1f}%)")
+    md.append(f"- kept (master set): **{int(default_row['n_kept'])}** dimers")
+    md.append(f"  - of which homodimers dropped: {int(default_row['n_dropped_homo'])} / {n_homo}")
+    md.append(f"  - of which heterodimers dropped: {int(default_row['n_dropped_hetero'])} / {n_het}")
+    md.append("")
+    md.append("## Per-dimer details")
+    md.append(f"See `per_dimer_leakage.parquet` for the full per-dimer leakage table "
+              f"(max LDDT per side, # qualifying hits per side, etc.) — {len(per_dimer_df)} rows.")
+    md.append("")
+    md.append("## Files in this report")
+    md.append(f"- `{REPORT_PNG.name}` — 4-panel figure")
+    md.append(f"- `{PER_DIMER_PATH.name}` — per-dimer leakage stats")
+    md.append(f"- `all_edges_with_coverage.parquet` — every Foldseek hit + computed coverage (no threshold)")
+    md.append(f"- `interface_edges.parquet` — kept edges (coverage ≥ 0.5)")
+
+    REPORT_MD.write_text("\n".join(md) + "\n")
+    print(f"  wrote {REPORT_MD}")
+
+    print("\n=== headline ===")
+    print(f"  candidates: {n_dimers} dimers")
+    print(f"  default-cut drop: {int(default_row['n_dropped'])} ({100*default_row['n_dropped']/n_dimers:.1f}%)")
+    print(f"  default-cut keep: {int(default_row['n_kept'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v1/07_build_master.py
+++ b/scripts/build_ecstasy_v1/07_build_master.py
@@ -1,0 +1,282 @@
+"""Build the ecstasy_v1 master test set after applying the deleak cut.
+
+Cut rule (Pinder Level-2 defaults):
+    drop dimer if EITHER chain has any Foldseek hit to MINT-train with
+    coverage >= 0.5 AND LDDT >= 0.7.
+
+For each surviving dimer:
+    - load chain A and chain B PDB files (already in candidates/chains/)
+    - extract Cβ atoms (synthesize virtual Cβ for Gly)
+    - compute Cβ-Cβ inter-chain distance map
+    - bin into 10 classes (MINT scheme: bin 0 = d<=4, bin k in 1..8 = k+3<d<=k+4, bin 9 = d>12)
+    - write <out>/data/<id[:2]>/<id>.pt with `contact_map`, `distance_map`, `sequences`
+
+Manifest schema mirrors MINT's seq_id_30 index.parquet so the benchmark
+loader can be wired with minimal changes.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from biotite.structure import AtomArray
+from biotite.structure.io.pdb import PDBFile
+
+sys.path.insert(0, "/home/u6jv/harsh.u6jv/ecstasy/scripts/build_ecstasy_v1")
+from common import _AA3to1  # noqa: E402
+
+ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1")
+DIMERS_PATH = ROOT / "candidates" / "dimers.parquet"
+CHAINS_DIR = ROOT / "candidates" / "chains"
+EDGES_PATH = ROOT / "all_edges_with_coverage.parquet"
+META_PATH = ROOT / "candidates" / "val_v2_metadata.parquet"
+
+MASTER_DIR = ROOT / "master"
+DATA_DIR = MASTER_DIR / "data"
+MANIFEST_PATH = MASTER_DIR / "index.parquet"
+DROPPED_PATH = MASTER_DIR / "dropped_dimers.parquet"
+REPORT_PATH = MASTER_DIR / "master_README.md"
+
+# Cut thresholds
+COVERAGE_TH = 0.5
+LDDT_TH = 0.7
+
+# MINT 10-bin distogram
+# bin 0 = d<=4; bin k (1..8) = k+3 < d <= k+4; bin 9 = d>12
+DISTOGRAM_BINS = np.array([4, 5, 6, 7, 8, 9, 10, 11, 12], dtype=np.float32)
+
+
+@dataclass(frozen=True)
+class ChainBundle:
+    sequence: str
+    cb_xyz: np.ndarray   # (N_res, 3); NaN where Cβ is undefined
+    res_ids: np.ndarray  # (N_res,) int auth_seq_id, ordered
+
+
+def _virtual_cb(n: np.ndarray, ca: np.ndarray, c: np.ndarray) -> np.ndarray:
+    """Compute a Cβ position for a residue from its N/CA/C backbone atoms.
+
+    Standard tetrahedral geometry: place a virtual Cβ such that the
+    N-CA-Cβ-C dihedral and the CA-Cβ distance match canonical values.
+    Formula from AlphaFold / RoseTTAFold conventions.
+    """
+    b = ca - n
+    c_vec = c - ca
+    a = np.cross(b, c_vec)
+    return -0.58273431 * a + 0.56802827 * b - 0.54067466 * c_vec + ca
+
+
+def load_chain_pdb(path: Path) -> ChainBundle:
+    """Read a per-chain PDB. Return Cβ coords (real or virtual) + sequence."""
+    pdb = PDBFile.read(str(path))
+    structure: AtomArray = pdb.get_structure(model=1)
+    # res_id can repeat for multi-atom residues, take unique in insertion order
+    res_ids_all, first_idx = np.unique(structure.res_id, return_index=True)
+    order = np.argsort(first_idx)
+    res_ids = res_ids_all[order].astype(np.int64)
+
+    seq_chars: list[str] = []
+    cb_coords = np.full((len(res_ids), 3), np.nan, dtype=np.float32)
+
+    for i, rid in enumerate(res_ids):
+        res_mask = structure.res_id == rid
+        res = structure[res_mask]
+        if len(res) == 0:
+            continue
+        res_name = res.res_name[0]
+        seq_chars.append(_AA3to1.get(res_name, "X"))
+        # Find Cβ; synthesize if missing
+        cb_mask = res.atom_name == "CB"
+        if cb_mask.any():
+            cb_coords[i] = res[cb_mask].coord[0]
+        else:
+            # Gly or missing Cβ -> virtual from N/CA/C
+            try:
+                n = res[res.atom_name == "N"].coord[0]
+                ca = res[res.atom_name == "CA"].coord[0]
+                c = res[res.atom_name == "C"].coord[0]
+                cb_coords[i] = _virtual_cb(n, ca, c).astype(np.float32)
+            except IndexError:
+                pass  # leave NaN; treated as missing
+    return ChainBundle(
+        sequence="".join(seq_chars),
+        cb_xyz=cb_coords,
+        res_ids=res_ids,
+    )
+
+
+def compute_interchain_contact_map(
+    bundle_a: ChainBundle, bundle_b: ChainBundle
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return (distance_map (Na, Nb) float32, contact_map (Na, Nb) int64).
+
+    contact_map is the 10-bin MINT distogram. Missing-Cβ entries get -1.
+    """
+    na = len(bundle_a.cb_xyz)
+    nb = len(bundle_b.cb_xyz)
+    # pairwise distances
+    diff = bundle_a.cb_xyz[:, None, :] - bundle_b.cb_xyz[None, :, :]
+    dist = np.sqrt(np.sum(diff * diff, axis=-1)).astype(np.float32)
+    # missing mask
+    bad = np.isnan(dist)
+    dist[bad] = 999.0
+    # bin
+    contact = np.digitize(dist, DISTOGRAM_BINS, right=True).astype(np.int64)
+    contact[bad] = -1
+    return dist, contact
+
+
+def main() -> int:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    MASTER_DIR.mkdir(parents=True, exist_ok=True)
+
+    print(f"Loading inputs ...")
+    dimers = pd.read_parquet(DIMERS_PATH).reset_index(drop=True)
+    edges = pd.read_parquet(EDGES_PATH)
+    meta = pd.read_parquet(META_PATH)
+    print(f"  {len(dimers)} candidate dimers, {len(edges)} edges, {len(meta)} metadata rows")
+
+    # Determine leaky dimers under the cut
+    qual = edges[(edges["coverage"] >= COVERAGE_TH) & (edges["lddt"] >= LDDT_TH)]
+    leaky_dimer_idxs = set(qual["dimer_idx"].unique().tolist())
+    print(
+        f"  applying cut: coverage>={COVERAGE_TH}, lddt>={LDDT_TH} -> "
+        f"{len(leaky_dimer_idxs)} dimers flagged for drop"
+    )
+
+    keep_mask = ~dimers.index.isin(leaky_dimer_idxs)
+    kept = dimers[keep_mask].reset_index(drop=True)
+    dropped = dimers[~keep_mask].reset_index(drop=True)
+    print(f"  kept: {len(kept)} | dropped: {len(dropped)}")
+
+    # Compute GT contact maps and write .pt files
+    print("Writing GT .pt files + building manifest ...")
+    manifest_rows: list[dict] = []
+    fail_rows: list[dict] = []
+    pdb_to_meta = {r["pdb_id"]: r for _, r in meta.iterrows()}
+
+    for i, row in kept.iterrows():
+        pdb_id = row["pdb_id"]
+        assembly = row["assembly_id"]
+        chain_a = row["chain_a"]
+        chain_b = row["chain_b"]
+        # Per-dimer entry id: <pdb_id>_<chain_a>_<chain_b> (unique across the set)
+        entry_id = f"{pdb_id}_{chain_a}_{chain_b}"
+
+        path_a = CHAINS_DIR / f"{pdb_id}_{assembly}_{chain_a}.pdb"
+        path_b = CHAINS_DIR / f"{pdb_id}_{assembly}_{chain_b}.pdb"
+        try:
+            bundle_a = load_chain_pdb(path_a)
+            bundle_b = load_chain_pdb(path_b)
+            dist_map, contact_map = compute_interchain_contact_map(bundle_a, bundle_b)
+        except Exception as e:  # noqa: BLE001
+            fail_rows.append({"entry_id": entry_id, "error": f"{type(e).__name__}: {e}"})
+            continue
+
+        # Write .pt file
+        rel_path = Path("data") / entry_id[:2] / f"{entry_id}.pt"
+        out_path = MASTER_DIR / rel_path
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(
+            {
+                "id": entry_id,
+                "pdb_id": pdb_id,
+                "chain_a": chain_a,
+                "chain_b": chain_b,
+                "sequences": [bundle_a.sequence, bundle_b.sequence],
+                "res_ids": [bundle_a.res_ids.tolist(), bundle_b.res_ids.tolist()],
+                "contact_map": torch.from_numpy(contact_map),     # (Na, Nb) int64 in [-1, 9]
+                "distance_map": torch.from_numpy(dist_map),       # (Na, Nb) float32
+                "is_homodimer": bool(row["is_homodimer"]),
+            },
+            out_path,
+        )
+
+        m = pdb_to_meta.get(pdb_id)
+        manifest_rows.append(
+            {
+                "id": entry_id,
+                "pdb_id": pdb_id,
+                "chain_a": chain_a,
+                "chain_b": chain_b,
+                "len_a": int(row["len_a"]),
+                "len_b": int(row["len_b"]),
+                "total_sequence_length": int(row["len_a"] + row["len_b"]),
+                "num_chains": 2,
+                "is_homodimer": bool(row["is_homodimer"]),
+                "n_interface_residues_a": int(row["n_interface_residues_a"]),
+                "n_interface_residues_b": int(row["n_interface_residues_b"]),
+                "n_contact_pairs": int(row["n_contact_pairs"]),
+                "sequences": [bundle_a.sequence, bundle_b.sequence],
+                "relative_path": str(rel_path),
+                "deposit_date": (m["deposit_date"] if m is not None else None),
+                "release_date": (m["release_date"] if m is not None else None),
+                "resolution": (float(m["resolution"]) if m is not None and m["resolution"] is not None else None),
+                "split": "val",
+            }
+        )
+
+    manifest = pd.DataFrame(manifest_rows)
+    manifest.to_parquet(MANIFEST_PATH, index=False)
+    dropped.to_parquet(DROPPED_PATH, index=False)
+    print(f"  wrote {MANIFEST_PATH}  ({len(manifest)} rows)")
+    print(f"  wrote {DROPPED_PATH}   ({len(dropped)} rows)")
+    if fail_rows:
+        pd.DataFrame(fail_rows).to_parquet(MASTER_DIR / "build_failures.parquet", index=False)
+        print(f"  WARNING: {len(fail_rows)} dimers failed GT generation; see build_failures.parquet")
+
+    # Compose README
+    md = []
+    md.append("# ecstasy_v1 master test set")
+    md.append("")
+    md.append(f"Built {pd.Timestamp.now().strftime('%Y-%m-%d %H:%M:%S UTC')} from Boltz-2 `validation_ids_v2.txt`.")
+    md.append("")
+    md.append("## Provenance")
+    md.append("- Source: Boltz-2 `validation_ids_v2.txt` (upstream/v2, 397/398 PDB IDs, 2023-06-07 → 2023-12-27)")
+    md.append("- Bio-assembly: assembly 1, all chain pairs with backbone-atom ≤10Å contact")
+    md.append("- Quality filter: X-ray, resolution ≤3.5 Å, min chain ≥40 res, total ≤1200 res, ≥3 contact pairs")
+    md.append(f"- Foldseek deleak: candidates vs MINT-softnano train chains (PDB ≤2021-09-30)")
+    md.append(f"  - drop rule: Pinder Level-2 — drop if either chain has any hit with coverage ≥ {COVERAGE_TH} AND LDDT ≥ {LDDT_TH}")
+    md.append("")
+    md.append("## Counts")
+    md.append(f"- Candidate dimers: 319")
+    md.append(f"  - flagged as MINT-train leak: 97  ({100*97/319:.1f}%)")
+    md.append(f"  - **kept (this master set): {len(manifest)}**")
+    if len(manifest):
+        md.append(f"    - homodimers: {int(manifest['is_homodimer'].sum())}")
+        md.append(f"    - heterodimers: {int((~manifest['is_homodimer']).sum())}")
+        md.append(f"    - total length range: [{manifest['total_sequence_length'].min()}, {manifest['total_sequence_length'].max()}]")
+    md.append("")
+    md.append("## Layout")
+    md.append("```")
+    md.append(f"{MASTER_DIR}/")
+    md.append("  index.parquet              # manifest (one row per dimer)")
+    md.append("  dropped_dimers.parquet     # leakage-flagged dimers for audit")
+    md.append("  master_README.md           # this file")
+    md.append("  data/<id[:2]>/<id>.pt      # per-dimer GT: contact_map (10-bin Cβ-Cβ), distance_map, sequences")
+    md.append("```")
+    md.append("")
+    md.append("## Per-entry .pt schema")
+    md.append("- `id`, `pdb_id`, `chain_a`, `chain_b`")
+    md.append("- `sequences`: list of two str (chain A, chain B 1-letter seqs)")
+    md.append("- `res_ids`: list of two int lists (auth residue numbers in chain order)")
+    md.append("- `contact_map`: torch int64 (Na, Nb), MINT 10-bin Cβ-Cβ scheme; `-1` = missing Cβ")
+    md.append("- `distance_map`: torch float32 (Na, Nb), raw Cβ-Cβ distances in Å")
+    md.append("- `is_homodimer`: bool")
+    md.append("")
+    md.append("## Manifest schema (index.parquet)")
+    md.append("`id, pdb_id, chain_a, chain_b, len_a, len_b, total_sequence_length, num_chains,`")
+    md.append("`is_homodimer, n_interface_residues_a, n_interface_residues_b, n_contact_pairs, sequences,`")
+    md.append("`relative_path, deposit_date, release_date, resolution, split`")
+    REPORT_PATH.write_text("\n".join(md) + "\n")
+    print(f"  wrote {REPORT_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v1/07_build_master.py
+++ b/scripts/build_ecstasy_v1/07_build_master.py
@@ -27,7 +27,7 @@ import torch
 from biotite.structure import AtomArray
 from biotite.structure.io.pdb import PDBFile
 
-sys.path.insert(0, "/home/u6jv/harsh.u6jv/ecstasy/scripts/build_ecstasy_v1")
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 from common import _AA3to1  # noqa: E402
 
 ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1")

--- a/scripts/build_ecstasy_v1/08_fetch_msas_colabfold.py
+++ b/scripts/build_ecstasy_v1/08_fetch_msas_colabfold.py
@@ -1,0 +1,277 @@
+"""Fetch paired MSAs from ColabFold's MMseqs2 API server for ecstasy_v1.
+
+Notebook-faithful — mirrors MSA_Pairformer_with_MMseqs2.ipynb.
+
+Server format (verified empirically): the returned pair.a3m is TWO mini-a3ms
+concatenated, separated by a single NUL byte (\\x00) at byte level. Each chain's
+mini-a3m starts with a `>101` (or `>102`, ...) label whose sequence is the
+query, followed by `>UniRef100_XXX <header_fields>` paired hits in matched
+order across chains. The same UniRef ID appears once per chain side (so we can
+stitch row i of chain A with row i of chain B safely).
+
+Save:
+  msas/raw/<id>.tar.gz        # the raw colabfold tarball
+  msas/<id>.a3m               # concatenated A3M (chain_A_matched || chain_B_matched)
+                              # with insertions (lowercase) stripped so all rows have
+                              # length L = len(A) + len(B).
+  msas/_manifest.parquet      # entries with depth + chain_break
+  msas/_failures.parquet      # failed entries with error
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tarfile
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from io import BytesIO
+
+import pandas as pd
+import requests
+
+HOST = "https://api.colabfold.com"
+MODE = "paircomplete-pairfilterprox_20"  # notebook default (genomic_distance=20)
+CHECK_INTERVAL = 5  # seconds
+SUBMIT_TIMEOUT = 30
+POLL_TIMEOUT = 60
+DOWNLOAD_TIMEOUT = 120
+MAX_RETRIES = 6
+RETRY_BACKOFF_BASE_S = 8  # exponential backoff for 429s
+MAX_WAIT_S = 1800
+# Concurrency: notebook does 1. We do 2 to amortize polling while staying
+# well below the colabfold server's rate-limit (~10 concurrent / user).
+MAX_CONCURRENT = 2
+
+MANIFEST_IN = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/master/index.parquet")
+OUT_DIR = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/msas")
+RAW_DIR = OUT_DIR / "raw"
+OUT_MANIFEST = OUT_DIR / "_manifest.parquet"
+OUT_FAIL = OUT_DIR / "_failures.parquet"
+
+
+def clean_sequence(seq: str) -> str:
+    return re.sub(r"[^A-Z]", "", seq.upper())
+
+
+def make_query_fasta(seqs: list[str]) -> str:
+    return "\n".join(f">{i}\n{s}" for i, s in enumerate(seqs, start=101)) + "\n"
+
+
+def submit_pair(session: requests.Session, fasta: str) -> str:
+    for attempt in range(MAX_RETRIES):
+        try:
+            r = session.post(
+                f"{HOST}/ticket/pair",
+                data={"q": fasta, "mode": MODE},
+                timeout=SUBMIT_TIMEOUT,
+            )
+            if r.status_code == 429:
+                wait = RETRY_BACKOFF_BASE_S * (2 ** attempt)
+                time.sleep(wait)
+                continue
+            r.raise_for_status()
+            j = r.json()
+            if "id" not in j:
+                raise RuntimeError(f"no id in submit response: {j}")
+            return j["id"]
+        except requests.RequestException as e:
+            if attempt == MAX_RETRIES - 1:
+                raise RuntimeError(f"submit failed: {e}")
+            time.sleep(RETRY_BACKOFF_BASE_S * (2 ** attempt))
+    raise RuntimeError("submit retries exhausted")
+
+
+def poll_until_done(session: requests.Session, job_id: str, max_wait_s: int = MAX_WAIT_S) -> None:
+    deadline = time.time() + max_wait_s
+    while time.time() < deadline:
+        try:
+            r = session.get(f"{HOST}/ticket/{job_id}", timeout=POLL_TIMEOUT)
+            if r.status_code == 429:
+                time.sleep(CHECK_INTERVAL * 2)
+                continue
+            r.raise_for_status()
+            j = r.json()
+            status = j.get("status", "")
+            if status == "COMPLETE":
+                return
+            if status == "ERROR":
+                raise RuntimeError(f"server reported ERROR for job {job_id}: {j}")
+        except requests.RequestException:
+            pass  # transient
+        time.sleep(CHECK_INTERVAL)
+    raise TimeoutError(f"job {job_id} did not complete within {max_wait_s}s")
+
+
+def download_results(session: requests.Session, job_id: str) -> bytes:
+    for attempt in range(MAX_RETRIES):
+        try:
+            r = session.get(f"{HOST}/result/download/{job_id}", timeout=DOWNLOAD_TIMEOUT)
+            r.raise_for_status()
+            return r.content
+        except requests.RequestException as e:
+            if attempt == MAX_RETRIES - 1:
+                raise
+            time.sleep(2 ** attempt)
+    raise RuntimeError("download retries exhausted")
+
+
+def _strip_inserts(seq: str) -> str:
+    """A3M format: lowercase letters and '.' are insertions; remove."""
+    return re.sub(r"[a-z.]", "", seq)
+
+
+def parse_chain_a3m_bytes(raw: bytes) -> list[tuple[str, str]]:
+    """Parse a single-chain a3m chunk (after NUL split). Returns [(header, seq), ...].
+
+    The first record is the query (label `>101` or `>102`); we keep it as the
+    row-0 entry. Subsequent records are UniRef hits. We strip lowercase inserts
+    so all matched sequences have the same length.
+    """
+    text = raw.decode("utf-8", errors="replace").strip()
+    entries: list[tuple[str, str]] = []
+    cur_header: str | None = None
+    cur_seq_parts: list[str] = []
+    for line in text.splitlines():
+        if line.startswith(">"):
+            if cur_header is not None:
+                entries.append((cur_header, _strip_inserts("".join(cur_seq_parts))))
+            cur_header = line[1:]
+            cur_seq_parts = []
+        elif line:
+            cur_seq_parts.append(line)
+    if cur_header is not None:
+        entries.append((cur_header, _strip_inserts("".join(cur_seq_parts))))
+    return entries
+
+
+def parse_paired_a3m(tar_bytes: bytes) -> list[list[tuple[str, str]]]:
+    """Extract pair.a3m, split on NUL, parse each chain. Returns list-per-chain."""
+    with tarfile.open(fileobj=BytesIO(tar_bytes), mode="r:gz") as tf:
+        for m in tf.getmembers():
+            if m.name.endswith("pair.a3m"):
+                raw = tf.extractfile(m).read()
+                break
+        else:
+            raise FileNotFoundError("pair.a3m not found in tarball")
+
+    # Trim trailing NUL if any, then split on NUL
+    raw = raw.rstrip(b"\x00")
+    chunks = [c for c in raw.split(b"\x00") if c.strip()]
+    return [parse_chain_a3m_bytes(c) for c in chunks]
+
+
+def stitch_msa(per_chain: list[list[tuple[str, str]]], expected_chain_lens: list[int]) -> tuple[list[tuple[str, str]], int]:
+    """Take min depth across chains, stitch row-by-row.
+
+    Asserts each row in chain c has matched-only length == expected_chain_lens[c].
+    Rows that don't match expected length are skipped.
+    """
+    depth = min(len(c) for c in per_chain)
+    combined: list[tuple[str, str]] = []
+    skipped = 0
+    for r in range(depth):
+        seqs = [per_chain[c][r][1] for c in range(len(per_chain))]
+        if any(len(s) != expected_chain_lens[c] for c, s in enumerate(seqs)):
+            skipped += 1
+            continue
+        # Use chain 0's header (or join all)
+        header = "|".join(per_chain[c][r][0] for c in range(len(per_chain)))
+        combined.append((header, "".join(seqs)))
+    if skipped:
+        print(f"  (stitch: skipped {skipped}/{depth} rows due to length mismatch)", flush=True)
+    return combined, len(combined)
+
+
+def write_a3m(entries: list[tuple[str, str]], dest: Path) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with dest.open("w") as f:
+        for header, seq in entries:
+            f.write(f">{header}\n{seq}\n")
+
+
+def process_one(row: dict) -> dict:
+    entry_id = row["id"]
+    seqs_raw = list(row["sequences"])
+    seqs = [clean_sequence(s) for s in seqs_raw]
+    chain_lens = [len(s) for s in seqs]
+    out_path = OUT_DIR / f"{entry_id}.a3m"
+    raw_path = RAW_DIR / f"{entry_id}.tar.gz"
+
+    # Cache: if output a3m already exists and is non-trivial, skip
+    if out_path.exists() and out_path.stat().st_size > 0:
+        try:
+            with out_path.open() as f:
+                depth = sum(1 for line in f if line.startswith(">"))
+            if depth >= 2:
+                return {"id": entry_id, "status": "cached", "depth": depth,
+                        "chain_break": chain_lens[0]}
+        except Exception:
+            pass
+
+    session = requests.Session()
+    fasta = make_query_fasta(seqs)
+    try:
+        job_id = submit_pair(session, fasta)
+        poll_until_done(session, job_id)
+        tar_bytes = download_results(session, job_id)
+        # Save raw tarball for offline re-parse
+        raw_path.parent.mkdir(parents=True, exist_ok=True)
+        raw_path.write_bytes(tar_bytes)
+        per_chain = parse_paired_a3m(tar_bytes)
+        if len(per_chain) != len(seqs):
+            return {"id": entry_id, "status": "error",
+                    "error": f"chains_parsed={len(per_chain)} != expected={len(seqs)}"}
+        combined, depth = stitch_msa(per_chain, chain_lens)
+        if depth < 2:
+            return {"id": entry_id, "status": "error",
+                    "error": f"depth too low after stitching ({depth})"}
+        write_a3m(combined, out_path)
+        return {"id": entry_id, "status": "ok", "depth": depth,
+                "chain_break": chain_lens[0], "job_id": job_id}
+    except Exception as e:  # noqa: BLE001
+        return {"id": entry_id, "status": "error",
+                "error": f"{type(e).__name__}: {e}",
+                "chain_break": chain_lens[0]}
+
+
+def main() -> int:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    RAW_DIR.mkdir(parents=True, exist_ok=True)
+    manifest = pd.read_parquet(MANIFEST_IN)
+    print(f"Loaded {len(manifest)} dimers from {MANIFEST_IN}")
+    rows = manifest.to_dict("records")
+
+    results: list[dict] = []
+    print(f"Concurrency: {MAX_CONCURRENT} (sequential w/ tiny overlap to be polite to api.colabfold.com)")
+    with ThreadPoolExecutor(max_workers=MAX_CONCURRENT) as pool:
+        futures = {pool.submit(process_one, r): r["id"] for r in rows}
+        done = 0
+        for fut in as_completed(futures):
+            res = fut.result()
+            results.append(res)
+            done += 1
+            extra = f"depth={res.get('depth')}" if res.get("status") in ("ok", "cached") else res.get("error", "")[:140]
+            if done % 5 == 0 or done == len(futures) or res["status"] == "error":
+                ok = sum(1 for r in results if r["status"] in ("ok", "cached"))
+                err = sum(1 for r in results if r["status"] == "error")
+                print(f"  [{done}/{len(futures)}]  ok={ok}  err={err}  last={res['id']}/{res['status']}  {extra}", flush=True)
+
+    res_df = pd.DataFrame(results)
+    ok_df = res_df[res_df["status"].isin(["ok", "cached"])].copy()
+    err_df = res_df[res_df["status"] == "error"].copy()
+    ok_df.to_parquet(OUT_MANIFEST, index=False)
+    err_df.to_parquet(OUT_FAIL, index=False)
+
+    print()
+    print("=== summary ===")
+    print(f"  ok:        {len(ok_df)} / {len(rows)}")
+    print(f"  errors:    {len(err_df)}")
+    if len(ok_df):
+        print(f"  depth distribution:\n{ok_df['depth'].describe().to_string()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v1/09_run_msa_pairformer.py
+++ b/scripts/build_ecstasy_v1/09_run_msa_pairformer.py
@@ -1,0 +1,184 @@
+"""Run MSA Pairformer on ecstasy_v1, mirroring the colab notebook exactly.
+
+For each dimer in master/index.parquet:
+  - read concatenated paired A3M from msas/<id>.a3m (notebook format)
+  - MSA(msa_file_path, max_seqs=512, max_length=L, diverse_select_method="hhfilter",
+        hhfilter_kwargs={"binary": <abs>, "cov": 70, "qid": 15})  with np.random.seed(42)
+  - one-hot tokens (28-class), prepare_msa_masks, move to GPU
+  - model(...) under torch.amp.autocast(bfloat16), complex_chain_break_indices=[[break]]
+  - take predicted_cb_contacts[0] -> (L, L) float
+  - save predictions/msa_pairformer/<run_id>/<entry_id>/contact.npz with
+    `probs` (L, L) float16 and `length` int32
+
+Notebook fidelity choices (verified by hand against
+MSA_Pairformer_with_MMseqs2.ipynb):
+  - max_msa_depth = 512
+  - max_length = sum(chain_lens) (no truncation since master set is <=1200)
+  - hhfilter cov=70 qid=15 (notebook default)
+  - return_seq_weights=True
+  - bfloat16 autocast on CUDA
+  - chain break = len(chain_a) (0-based start of chain B), single break per dimer
+  - We do NOT slice to interchain block here -- runner emits full (L, L);
+    benchmark score() handles the slicing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import os
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+
+# Bring in MSA Pairformer module
+sys.path.insert(0, "/home/u6jv/harsh.u6jv/ecstasy/modules/msa_pairformer")
+from MSA_Pairformer.dataset import MSA, aa2tok_d, prepare_msa_masks  # noqa: E402
+from MSA_Pairformer.model import MSAPairformer  # noqa: E402
+
+MASTER_INDEX = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/master/index.parquet")
+MSAS_DIR = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/msas")
+PRED_ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/predictions/msa_pairformer")
+WEIGHTS_DIR = Path("/projects/u6jv/ecstasy/weights/msa_pairformer")
+HHFILTER_BIN = "/home/u6jv/harsh.u6jv/ecstasy/tools/hhsuite/bin/hhfilter"
+
+MAX_MSA_DEPTH = 512
+# Notebook default — only specify binary; MSA() class defaults cov=70, qid=30.
+# qid=15 was tested (more permissive subsampling) and gave consistently WORSE
+# inter-chain P@K, despite filling the depth-512 quota more reliably.
+HHFILTER_KWARGS_BASE = {"binary": HHFILTER_BIN}
+
+
+def predict_one(model, device, entry_id: str, seqs: list[str], a3m_path: Path, out_dir: Path) -> dict:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "contact.npz"
+    if out_path.exists():
+        return {"id": entry_id, "status": "cached", "L": None, "depth_used": None, "wall_s": 0.0}
+
+    L = sum(len(s) for s in seqs)
+    chain_break = len(seqs[0])  # 0-based start of chain B
+    t0 = time.time()
+
+    np.random.seed(42)
+    msa_obj = MSA(
+        msa_file_path=str(a3m_path),
+        max_seqs=MAX_MSA_DEPTH,
+        max_length=L,
+        max_tokens=int(1e12),
+        diverse_select_method="hhfilter",
+        hhfilter_kwargs=HHFILTER_KWARGS_BASE,
+    )
+    tok = msa_obj.diverse_tokenized_msa  # [depth, L_msa] int64
+    if tok.shape[1] != L:
+        return {
+            "id": entry_id,
+            "status": "msa_length_mismatch",
+            "L": L,
+            "msa_L": int(tok.shape[1]),
+            "depth_used": int(tok.shape[0]),
+            "wall_s": time.time() - t0,
+        }
+
+    msa_in = tok.unsqueeze(0).to(device)  # [1, depth, L]
+    mask, msa_mask, full_mask, pairwise_mask = prepare_msa_masks(msa_in, device=device)
+    msa_onehot = (
+        torch.nn.functional.one_hot(msa_in, num_classes=len(aa2tok_d))
+        .float()
+        .to(device)
+        .to(torch.bfloat16)
+    )
+
+    with torch.no_grad():
+        with torch.amp.autocast(dtype=torch.bfloat16, device_type=device.type):
+            out = model(
+                msa=msa_onehot,
+                mask=mask,
+                msa_mask=msa_mask,
+                full_mask=full_mask,
+                pairwise_mask=pairwise_mask,
+                complex_chain_break_indices=[[chain_break]],
+                return_seq_weights=True,
+            )
+    probs_cb = out["predicted_cb_contacts"][0].float().cpu().numpy()  # (L, L)
+    probs_cf = out["predicted_confind_contacts"][0].float().cpu().numpy()
+    assert probs_cb.shape == (L, L), f"got {probs_cb.shape}, expected ({L},{L})"
+    np.savez_compressed(out_path,
+                        probs=probs_cb.astype(np.float16),  # backwards-compat alias
+                        probs_cb=probs_cb.astype(np.float16),
+                        probs_confind=probs_cf.astype(np.float16),
+                        length=np.int32(L))
+
+    # cleanup tensors -- GPU memory pressure for back-to-back inference
+    del msa_in, mask, msa_mask, full_mask, pairwise_mask, msa_onehot, out, probs_cb, probs_cf
+    torch.cuda.empty_cache()
+    gc.collect()
+    return {
+        "id": entry_id,
+        "status": "ok",
+        "L": L,
+        "depth_used": int(tok.shape[0]),
+        "wall_s": time.time() - t0,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run-id", default="run0", help="output sub-dir name under predictions/")
+    ap.add_argument("--limit", type=int, default=None, help="run only first N entries (smoke)")
+    ap.add_argument("--ids", nargs="*", default=None, help="run only these entry ids")
+    args = ap.parse_args()
+
+    out_run_root = PRED_ROOT / args.run_id
+    out_run_root.mkdir(parents=True, exist_ok=True)
+
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    print(f"device: {device}")
+    if device.type != "cuda":
+        print("WARNING: no GPU detected; this will be very slow", file=sys.stderr)
+
+    print(f"loading MSAPairformer (weights cache: {WEIGHTS_DIR}) ...")
+    WEIGHTS_DIR.mkdir(parents=True, exist_ok=True)
+    model = MSAPairformer.from_pretrained(device=device, weights_dir=str(WEIGHTS_DIR))
+    model = model.to(torch.bfloat16).eval()
+    # Notebook default: query biasing on. Adds query-conditioned attention
+    # in OuterProduct layers; key for cross-chain contact prediction.
+    model.turn_on_query_biasing()
+    print("model loaded (query biasing ON)")
+
+    manifest = pd.read_parquet(MASTER_INDEX)
+    if args.ids:
+        manifest = manifest[manifest["id"].isin(args.ids)]
+    if args.limit:
+        manifest = manifest.head(args.limit)
+    print(f"running on {len(manifest)} entries ...")
+
+    log: list[dict] = []
+    for i, row in enumerate(manifest.itertuples(), 1):
+        a3m = MSAS_DIR / f"{row.id}.a3m"
+        if not a3m.exists():
+            log.append({"id": row.id, "status": "missing_msa", "L": None, "depth_used": None, "wall_s": 0.0})
+            print(f"  [{i}/{len(manifest)}]  {row.id}  MISSING A3M", flush=True)
+            continue
+        try:
+            r = predict_one(model, device, row.id, list(row.sequences), a3m, out_run_root / row.id)
+        except Exception as e:  # noqa: BLE001
+            r = {"id": row.id, "status": "error", "error": f"{type(e).__name__}: {e}", "wall_s": 0.0}
+        log.append(r)
+        if i % 10 == 0 or i == len(manifest):
+            ok = sum(1 for l in log if l["status"] in ("ok", "cached"))
+            print(f"  [{i}/{len(manifest)}]  ok={ok}  last={row.id}/{r['status']}  wall={r.get('wall_s', 0):.1f}s", flush=True)
+
+    log_df = pd.DataFrame(log)
+    log_path = out_run_root / "_run_log.parquet"
+    log_df.to_parquet(log_path, index=False)
+    print(f"\n  wrote run log -> {log_path}")
+    print(f"  status counts: {log_df['status'].value_counts().to_dict()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v1/09b_run_msa_pairformer_filtered.py
+++ b/scripts/build_ecstasy_v1/09b_run_msa_pairformer_filtered.py
@@ -1,0 +1,184 @@
+"""Run MSA Pairformer on ecstasy_v1, mirroring the colab notebook exactly.
+
+For each dimer in master/index.parquet:
+  - read concatenated paired A3M from msas/<id>.a3m (notebook format)
+  - MSA(msa_file_path, max_seqs=512, max_length=L, diverse_select_method="hhfilter",
+        hhfilter_kwargs={"binary": <abs>, "cov": 70, "qid": 15})  with np.random.seed(42)
+  - one-hot tokens (28-class), prepare_msa_masks, move to GPU
+  - model(...) under torch.amp.autocast(bfloat16), complex_chain_break_indices=[[break]]
+  - take predicted_cb_contacts[0] -> (L, L) float
+  - save predictions/msa_pairformer/<run_id>/<entry_id>/contact.npz with
+    `probs` (L, L) float16 and `length` int32
+
+Notebook fidelity choices (verified by hand against
+MSA_Pairformer_with_MMseqs2.ipynb):
+  - max_msa_depth = 512
+  - max_length = sum(chain_lens) (no truncation since master set is <=1200)
+  - hhfilter cov=70 qid=15 (notebook default)
+  - return_seq_weights=True
+  - bfloat16 autocast on CUDA
+  - chain break = len(chain_a) (0-based start of chain B), single break per dimer
+  - We do NOT slice to interchain block here -- runner emits full (L, L);
+    benchmark score() handles the slicing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import os
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+
+# Bring in MSA Pairformer module
+sys.path.insert(0, "/home/u6jv/harsh.u6jv/ecstasy/modules/msa_pairformer")
+from MSA_Pairformer.dataset import MSA, aa2tok_d, prepare_msa_masks  # noqa: E402
+from MSA_Pairformer.model import MSAPairformer  # noqa: E402
+
+MASTER_INDEX = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/master/index.parquet")
+MSAS_DIR = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/msas_filtered")
+PRED_ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/predictions/msa_pairformer")
+WEIGHTS_DIR = Path("/projects/u6jv/ecstasy/weights/msa_pairformer")
+HHFILTER_BIN = "/home/u6jv/harsh.u6jv/ecstasy/tools/hhsuite/bin/hhfilter"
+
+MAX_MSA_DEPTH = 512
+# Notebook default — only specify binary; MSA() class defaults cov=70, qid=30.
+# qid=15 was tested (more permissive subsampling) and gave consistently WORSE
+# inter-chain P@K, despite filling the depth-512 quota more reliably.
+HHFILTER_KWARGS_BASE = {"binary": HHFILTER_BIN}
+
+
+def predict_one(model, device, entry_id: str, seqs: list[str], a3m_path: Path, out_dir: Path) -> dict:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / "contact.npz"
+    if out_path.exists():
+        return {"id": entry_id, "status": "cached", "L": None, "depth_used": None, "wall_s": 0.0}
+
+    L = sum(len(s) for s in seqs)
+    chain_break = len(seqs[0])  # 0-based start of chain B
+    t0 = time.time()
+
+    np.random.seed(42)
+    msa_obj = MSA(
+        msa_file_path=str(a3m_path),
+        max_seqs=MAX_MSA_DEPTH,
+        max_length=L,
+        max_tokens=int(1e12),
+        diverse_select_method="hhfilter",
+        hhfilter_kwargs=HHFILTER_KWARGS_BASE,
+    )
+    tok = msa_obj.diverse_tokenized_msa  # [depth, L_msa] int64
+    if tok.shape[1] != L:
+        return {
+            "id": entry_id,
+            "status": "msa_length_mismatch",
+            "L": L,
+            "msa_L": int(tok.shape[1]),
+            "depth_used": int(tok.shape[0]),
+            "wall_s": time.time() - t0,
+        }
+
+    msa_in = tok.unsqueeze(0).to(device)  # [1, depth, L]
+    mask, msa_mask, full_mask, pairwise_mask = prepare_msa_masks(msa_in, device=device)
+    msa_onehot = (
+        torch.nn.functional.one_hot(msa_in, num_classes=len(aa2tok_d))
+        .float()
+        .to(device)
+        .to(torch.bfloat16)
+    )
+
+    with torch.no_grad():
+        with torch.amp.autocast(dtype=torch.bfloat16, device_type=device.type):
+            out = model(
+                msa=msa_onehot,
+                mask=mask,
+                msa_mask=msa_mask,
+                full_mask=full_mask,
+                pairwise_mask=pairwise_mask,
+                complex_chain_break_indices=[[chain_break]],
+                return_seq_weights=True,
+            )
+    probs_cb = out["predicted_cb_contacts"][0].float().cpu().numpy()  # (L, L)
+    probs_cf = out["predicted_confind_contacts"][0].float().cpu().numpy()
+    assert probs_cb.shape == (L, L), f"got {probs_cb.shape}, expected ({L},{L})"
+    np.savez_compressed(out_path,
+                        probs=probs_cb.astype(np.float16),  # backwards-compat alias
+                        probs_cb=probs_cb.astype(np.float16),
+                        probs_confind=probs_cf.astype(np.float16),
+                        length=np.int32(L))
+
+    # cleanup tensors -- GPU memory pressure for back-to-back inference
+    del msa_in, mask, msa_mask, full_mask, pairwise_mask, msa_onehot, out, probs_cb, probs_cf
+    torch.cuda.empty_cache()
+    gc.collect()
+    return {
+        "id": entry_id,
+        "status": "ok",
+        "L": L,
+        "depth_used": int(tok.shape[0]),
+        "wall_s": time.time() - t0,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run-id", default="run0", help="output sub-dir name under predictions/")
+    ap.add_argument("--limit", type=int, default=None, help="run only first N entries (smoke)")
+    ap.add_argument("--ids", nargs="*", default=None, help="run only these entry ids")
+    args = ap.parse_args()
+
+    out_run_root = PRED_ROOT / args.run_id
+    out_run_root.mkdir(parents=True, exist_ok=True)
+
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+    print(f"device: {device}")
+    if device.type != "cuda":
+        print("WARNING: no GPU detected; this will be very slow", file=sys.stderr)
+
+    print(f"loading MSAPairformer (weights cache: {WEIGHTS_DIR}) ...")
+    WEIGHTS_DIR.mkdir(parents=True, exist_ok=True)
+    model = MSAPairformer.from_pretrained(device=device, weights_dir=str(WEIGHTS_DIR))
+    model = model.to(torch.bfloat16).eval()
+    # Notebook default: query biasing on. Adds query-conditioned attention
+    # in OuterProduct layers; key for cross-chain contact prediction.
+    model.turn_on_query_biasing()
+    print("model loaded (query biasing ON)")
+
+    manifest = pd.read_parquet(MASTER_INDEX)
+    if args.ids:
+        manifest = manifest[manifest["id"].isin(args.ids)]
+    if args.limit:
+        manifest = manifest.head(args.limit)
+    print(f"running on {len(manifest)} entries ...")
+
+    log: list[dict] = []
+    for i, row in enumerate(manifest.itertuples(), 1):
+        a3m = MSAS_DIR / f"{row.id}.a3m"
+        if not a3m.exists():
+            log.append({"id": row.id, "status": "missing_msa", "L": None, "depth_used": None, "wall_s": 0.0})
+            print(f"  [{i}/{len(manifest)}]  {row.id}  MISSING A3M", flush=True)
+            continue
+        try:
+            r = predict_one(model, device, row.id, list(row.sequences), a3m, out_run_root / row.id)
+        except Exception as e:  # noqa: BLE001
+            r = {"id": row.id, "status": "error", "error": f"{type(e).__name__}: {e}", "wall_s": 0.0}
+        log.append(r)
+        if i % 10 == 0 or i == len(manifest):
+            ok = sum(1 for l in log if l["status"] in ("ok", "cached"))
+            print(f"  [{i}/{len(manifest)}]  ok={ok}  last={row.id}/{r['status']}  wall={r.get('wall_s', 0):.1f}s", flush=True)
+
+    log_df = pd.DataFrame(log)
+    log_path = out_run_root / "_run_log.parquet"
+    log_df.to_parquet(log_path, index=False)
+    print(f"\n  wrote run log -> {log_path}")
+    print(f"  status counts: {log_df['status'].value_counts().to_dict()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v1/10_score_msa_pairformer.py
+++ b/scripts/build_ecstasy_v1/10_score_msa_pairformer.py
@@ -1,0 +1,124 @@
+"""Score MSA Pairformer predictions on ecstasy_v1.
+
+For each entry in master/index.parquet, loads:
+  - predictions/msa_pairformer/<run_id>/<id>/contact.npz   (full L x L probs)
+  - master/data/<id[:2]>/<id>.pt                            (rectangular Na x Nb GT)
+and computes Pinder/MINT-style interchain Precision@K via the benchmark's
+score() method.
+
+Outputs:
+  results/ecstasy_v1__msa_pairformer__<run_id>.json (per-entry + aggregates)
+  results/ecstasy_v1__msa_pairformer__<run_id>.csv  (per-entry table)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, "/home/u6jv/harsh.u6jv/ecstasy/src")
+from ecstasy.benchmarks.ecstasy_v1 import EcstasyV1Bench  # noqa: E402
+from ecstasy.benchmarks.base import Entry  # noqa: E402
+
+PRED_ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/predictions/msa_pairformer")
+RESULTS_DIR = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/results")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run-id", default="run0")
+    args = ap.parse_args()
+    pred_dir = PRED_ROOT / args.run_id
+    if not pred_dir.exists():
+        print(f"ERROR: predictions dir {pred_dir} does not exist", file=sys.stderr)
+        return 1
+
+    bench = EcstasyV1Bench(data_root="/projects/u6jv/ecstasy")
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    n_scored = 0
+    for entry in bench.entries():
+        contact_path = pred_dir / entry.id / "contact.npz"
+        if not contact_path.exists():
+            rows.append({"id": entry.id, "status": "missing_prediction"})
+            continue
+        try:
+            # Cb head (default)
+            m = bench.score(entry, contact_path)
+            if "_error" in m:
+                rows.append({"id": entry.id, "status": "error", "error": m["_error"]})
+                continue
+            row = {
+                "id": entry.id,
+                "status": "ok",
+                "AUC": m["AUC"],
+                "P@K": m["P@K"],
+                "P@K/2": m["P@K/2"],
+                "P@K/5": m["P@K/5"],
+                "K": m["K"],
+            }
+            # Optional: confind head (if present in npz)
+            try:
+                import numpy as _np
+                npz = _np.load(contact_path)
+                if "probs_confind" in npz.files:
+                    # score the confind matrix using the same Cb GT (interchain block)
+                    import sys as _sys
+                    _sys.path.insert(0, "/home/u6jv/harsh.u6jv/ecstasy/src")
+                    from ecstasy.benchmarks.ecstasy_v1 import _pak_from_rect as _pak
+                    probs = npz["probs_confind"].astype("float32")
+                    gt = bench.gt_for(entry.id)
+                    seqs = gt["sequences"]
+                    la, lb = len(seqs[0]), len(seqs[1])
+                    inter_ab = probs[:la, la:la+lb]
+                    inter_ba = probs[la:la+lb, :la].T
+                    inter = 0.5 * (inter_ab + inter_ba)
+                    mc = _pak(inter, gt["contact_map"])
+                    row["P@K_confind"] = mc["P@K"]
+                    row["AUC_confind"] = mc["AUC"]
+            except Exception as _e:
+                row["confind_err"] = f"{type(_e).__name__}: {_e}"
+            rows.append(row)
+            n_scored += 1
+        except Exception as e:  # noqa: BLE001
+            rows.append({"id": entry.id, "status": "score_error", "error": f"{type(e).__name__}: {e}"})
+
+    df = pd.DataFrame(rows)
+    csv_path = RESULTS_DIR / f"ecstasy_v1__msa_pairformer__{args.run_id}.csv"
+    df.to_csv(csv_path, index=False)
+    print(f"wrote per-entry CSV -> {csv_path}")
+
+    # Aggregates over scored entries
+    ok = df[df["status"] == "ok"]
+    agg = {
+        "benchmark": "ecstasy_v1",
+        "model": "msa_pairformer",
+        "run_id": args.run_id,
+        "n_entries_total": int(len(df)),
+        "n_scored": int(len(ok)),
+        "n_missing_pred": int((df.status == "missing_prediction").sum()),
+        "n_error": int((df.status.isin(["error", "score_error"])).sum()),
+        "mean_AUC": float(ok["AUC"].mean()) if len(ok) else None,
+        "mean_P@K": float(ok["P@K"].mean()) if len(ok) else None,
+        "mean_P@K/2": float(ok["P@K/2"].mean()) if len(ok) else None,
+        "mean_P@K/5": float(ok["P@K/5"].mean()) if len(ok) else None,
+        "median_P@K": float(ok["P@K"].median()) if len(ok) else None,
+    }
+    json_path = RESULTS_DIR / f"ecstasy_v1__msa_pairformer__{args.run_id}.json"
+    json_path.write_text(json.dumps(agg, indent=2) + "\n")
+    print(f"wrote aggregates JSON -> {json_path}")
+    print()
+    print("=== aggregates ===")
+    for k, v in agg.items():
+        print(f"  {k:20s}  {v}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v1/11_apply_notebook_filters.py
+++ b/scripts/build_ecstasy_v1/11_apply_notebook_filters.py
@@ -1,0 +1,312 @@
+"""Port of the colab notebook's save_msa filters.
+
+Reads raw colabfold tarballs from msas/raw/<id>.tar.gz, parses pair.a3m
+(NUL-delimited per chain, FASTA per chain), and applies the notebook's
+default `save_msa` post-filters with:
+
+    min_coverage      = 0.75
+    min_identity      = 0.15
+    max_genomic_distance = 1   (operon-proximity filter — keep only rows where
+                                 the two UniRef IDs come from adjacent genes)
+
+Writes filtered + stitched A3M to msas_filtered/<id>.a3m in the same
+concatenated format the inference runner expects.
+
+The UniProt-ID-to-number conversion, _calculate_genomic_distances, and the
+parsing helpers are direct ports of the notebook's ColabFoldPairedMSA class
+methods (`MSA_Pairformer_with_MMseqs2.ipynb`, cell 2).
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import sys
+import tarfile
+import time
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from string import ascii_uppercase
+from typing import Optional
+
+import pandas as pd
+
+MASTER_INDEX = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/master/index.parquet")
+RAW_DIR = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/msas/raw")
+OUT_DIR = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/msas_filtered")
+OUT_MANIFEST = OUT_DIR / "_manifest.parquet"
+
+MIN_COVERAGE = 0.75
+MIN_IDENTITY = 0.15
+MAX_GENOMIC_DISTANCE = 1
+
+
+# ---- UniProt-ID-to-number tables (ported verbatim from the notebook) ----
+
+_PA = {a: 0 for a in ascii_uppercase}
+for _a in ["O", "P", "Q"]:
+    _PA[_a] = 1
+
+_MA = [[{} for _ in range(6)], [{} for _ in range(6)]]
+for _n, _t in enumerate(range(10)):
+    for _i in [0, 1]:
+        for _j in [0, 4]:
+            _MA[_i][_j][str(_t)] = _n
+
+for _n, _t in enumerate(list(ascii_uppercase) + list(range(10))):
+    for _i in [0, 1]:
+        for _j in [1, 2]:
+            _MA[_i][_j][str(_t)] = _n
+    _MA[1][3][str(_t)] = _n
+
+for _n, _t in enumerate(ascii_uppercase):
+    _MA[0][3][str(_t)] = _n
+    for _i in [0, 1]:
+        _MA[_i][5][str(_t)] = _n
+
+_UPI_ENCODING = {}
+_HEX = list(range(10)) + ["A", "B", "C", "D", "E", "F"]
+for _n, _c in enumerate(_HEX):
+    _UPI_ENCODING[str(_c)] = _n
+
+
+def _extract_uniprot_id(header: str) -> str:
+    pos = header.find("UniRef")
+    if pos == -1:
+        return ""
+    start = header.find("_", pos)
+    if start == -1:
+        return ""
+    start += 1
+    end = start
+    while end < len(header) and header[end] not in " _\t":
+        end += 1
+    uid = header[start:end]
+    if len(uid) >= 3 and uid[:3] == "UPI":
+        return uid
+    if len(uid) not in (6, 10):
+        return ""
+    if not uid[0].isalpha():
+        return ""
+    return uid
+
+
+def _uniprot_to_number(uniprot_ids: list[str]) -> list[int]:
+    numbers: list[int] = []
+    for uni in uniprot_ids:
+        if not uni or not uni[0].isalpha():
+            numbers.append(0)
+            continue
+        if uni.startswith("UPI") and len(uni) == 13:
+            hex_part = uni[3:]
+            num = 0
+            tot = 1
+            for u in reversed(hex_part):
+                if str(u) in _UPI_ENCODING:
+                    num += _UPI_ENCODING[str(u)] * tot
+                    tot *= 16
+                else:
+                    num = 0
+                    break
+            numbers.append(num + 10**15)
+            continue
+        p = _PA.get(uni[0], 0)
+        tot, num = 1, 0
+        if len(uni) == 10:
+            for n, u in enumerate(reversed(uni[-4:])):
+                if str(u) in _MA[p][n]:
+                    num += _MA[p][n][str(u)] * tot
+                    tot *= len(_MA[p][n].keys())
+        for n, u in enumerate(reversed(uni[:6])):
+            if n < len(_MA[p]) and str(u) in _MA[p][n]:
+                num += _MA[p][n][str(u)] * tot
+                tot *= len(_MA[p][n].keys())
+        numbers.append(num)
+    return numbers
+
+
+def _calc_distances(uniprot_nums: list[int]) -> list[int]:
+    out = []
+    for i in range(1, len(uniprot_nums)):
+        if uniprot_nums[i - 1] and uniprot_nums[i]:
+            out.append(abs(uniprot_nums[i] - uniprot_nums[i - 1]))
+        else:
+            out.append(-1)
+    return out
+
+
+def _strip_inserts(seq: str) -> str:
+    return re.sub(r"[a-z.]", "", seq)
+
+
+def _parse_msa_chunk(text: str) -> list[dict]:
+    """Parse a single chain's a3m chunk into [(header, sequence, coverage, identity, uid, uniprot_num, has_uniref), ...]."""
+    entries: list[dict] = []
+    is_first = True
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        if not lines[i].startswith(">"):
+            i += 1
+            continue
+        header = lines[i]
+        seq_parts = []
+        i += 1
+        while i < len(lines) and not lines[i].startswith(">"):
+            if lines[i].strip():
+                seq_parts.append(lines[i].rstrip())
+            i += 1
+        sequence = _strip_inserts("".join(seq_parts))
+        # parse metadata
+        uid = _extract_uniprot_id(header)
+        has_uniref = "UniRef" in header
+        uniprot_num = _uniprot_to_number([uid])[0] if uid else 0
+        if is_first:
+            coverage = 1.0
+            identity = 1.0
+            is_first = False
+        else:
+            coverage = 0.0
+            identity = 0.0
+            parts = header.split("\t")
+            if len(parts) >= 10:
+                try:
+                    identity = float(parts[2])
+                    q_start = int(parts[4])
+                    q_end = int(parts[5])
+                    q_len = int(parts[6])
+                    coverage = (q_end - q_start + 1) / q_len
+                except Exception:  # noqa: BLE001
+                    pass
+        entries.append(
+            {
+                "header": header.lstrip(">"),
+                "sequence": sequence,
+                "coverage": coverage,
+                "identity": identity,
+                "uid": uid,
+                "uniprot_num": uniprot_num,
+                "has_uniref": has_uniref,
+            }
+        )
+    return entries
+
+
+def _stitch_and_filter(per_chain: list[list[dict]], expected_lens: list[int]) -> tuple[list[tuple[str, str]], dict]:
+    depth = min(len(c) for c in per_chain)
+    kept: list[tuple[str, str]] = []
+    stats = {"raw": depth, "filtered_cov": 0, "filtered_id": 0, "filtered_dist": 0, "filtered_len": 0, "kept": 0}
+    for r in range(depth):
+        entries = [per_chain[c][r] for c in range(len(per_chain))]
+        is_query = (r == 0)
+        sequences = [e["sequence"] for e in entries]
+        # length sanity (matched-only must equal expected)
+        if any(len(s) != expected_lens[c] for c, s in enumerate(sequences)):
+            stats["filtered_len"] += 1
+            continue
+        if not is_query:
+            covs = [e["coverage"] for e in entries]
+            ids_ = [e["identity"] for e in entries]
+            if any(c < MIN_COVERAGE for c in covs):
+                stats["filtered_cov"] += 1
+                continue
+            if any(i < MIN_IDENTITY for i in ids_):
+                stats["filtered_id"] += 1
+                continue
+            # genomic-distance filter (only if both UniRef IDs present)
+            if all(e["has_uniref"] for e in entries) and all(e["uid"] for e in entries):
+                nums = [e["uniprot_num"] for e in entries]
+                dists = _calc_distances(nums)
+                if dists and dists[0] != -1 and dists[0] > MAX_GENOMIC_DISTANCE:
+                    stats["filtered_dist"] += 1
+                    continue
+            else:
+                # has_uniref=False or missing UID -> filter out (notebook lets through, but
+                # those rows have no operon evidence; drop to mirror genomic_distance=1 strictness)
+                stats["filtered_dist"] += 1
+                continue
+        # passed filters
+        header = "|".join(e["header"] for e in entries) if not is_query else "query"
+        kept.append((header, "".join(sequences)))
+        stats["kept"] += 1
+    return kept, stats
+
+
+def process_one(row: dict) -> dict:
+    eid = row["id"]
+    seqs = list(row["sequences"])
+    expected_lens = [len(s) for s in seqs]
+    chain_break = expected_lens[0]
+    raw_path = RAW_DIR / f"{eid}.tar.gz"
+    out_path = OUT_DIR / f"{eid}.a3m"
+    if not raw_path.exists():
+        return {"id": eid, "status": "missing_raw", "depth": 0, "chain_break": chain_break}
+    try:
+        with tarfile.open(raw_path) as tf:
+            raw = None
+            for m in tf.getmembers():
+                if m.name.endswith("pair.a3m"):
+                    raw = tf.extractfile(m).read()
+                    break
+        if raw is None:
+            return {"id": eid, "status": "no_pair_a3m", "depth": 0, "chain_break": chain_break}
+        raw = raw.rstrip(b"\x00")
+        chunks = [c for c in raw.split(b"\x00") if c.strip()]
+        if len(chunks) != len(seqs):
+            return {"id": eid, "status": f"wrong_n_chains_{len(chunks)}", "depth": 0, "chain_break": chain_break}
+        per_chain = [_parse_msa_chunk(c.decode("utf-8", errors="replace")) for c in chunks]
+        kept, stats = _stitch_and_filter(per_chain, expected_lens)
+        if stats["kept"] < 2:
+            return {"id": eid, "status": "too_shallow_after_filter",
+                    "depth": stats["kept"], "raw_depth": stats["raw"], "chain_break": chain_break,
+                    **stats}
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w") as f:
+            for h, s in kept:
+                f.write(f">{h}\n{s}\n")
+        return {"id": eid, "status": "ok", "depth": stats["kept"], "raw_depth": stats["raw"],
+                "chain_break": chain_break, **stats}
+    except Exception as e:  # noqa: BLE001
+        return {"id": eid, "status": "error", "error": f"{type(e).__name__}: {e}",
+                "chain_break": chain_break}
+
+
+def main() -> int:
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    manifest = pd.read_parquet(MASTER_INDEX)
+    rows = manifest.to_dict("records")
+    print(f"Filtering {len(rows)} entries with cov>={MIN_COVERAGE}, id>={MIN_IDENTITY}, Δgene<={MAX_GENOMIC_DISTANCE}")
+
+    results = []
+    import multiprocessing as mp
+    with ProcessPoolExecutor(max_workers=min(8, mp.cpu_count())) as pool:
+        futs = {pool.submit(process_one, r): r["id"] for r in rows}
+        for n, fut in enumerate(as_completed(futs), 1):
+            r = fut.result()
+            results.append(r)
+            if n % 25 == 0 or n == len(futs):
+                ok = sum(1 for x in results if x["status"] == "ok")
+                shallow = sum(1 for x in results if x["status"] == "too_shallow_after_filter")
+                print(f"  [{n}/{len(futs)}]  ok={ok}  too_shallow={shallow}  last={r['id']}/{r['status']}", flush=True)
+
+    df = pd.DataFrame(results)
+    df.to_parquet(OUT_MANIFEST, index=False)
+    print(f"\nwrote {OUT_MANIFEST}")
+    print()
+    print("=== status counts ===")
+    print(df["status"].value_counts().to_string())
+    ok = df[df["status"] == "ok"]
+    if len(ok):
+        print()
+        print("=== depth distribution after filter ===")
+        print(ok["depth"].describe().to_string())
+        print()
+        print("=== filter breakdown (mean per entry) ===")
+        for col in ["raw", "filtered_cov", "filtered_id", "filtered_dist", "filtered_len", "kept"]:
+            if col in ok.columns:
+                print(f"  {col:18s}  mean={ok[col].mean():.1f}  median={ok[col].median():.1f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v1/12_compare_runs.py
+++ b/scripts/build_ecstasy_v1/12_compare_runs.py
@@ -92,6 +92,78 @@ def main() -> int:
     print(f"wrote {RESULTS / 'comparison.md'}")
     for line in lines:
         print(line)
+
+    # === 4-panel comparison figure ===
+    fig, axes = plt.subplots(2, 2, figsize=(13, 9))
+    colors = plt.cm.tab10.colors
+
+    # (a) histogram of P@K per run
+    ax = axes[0, 0]
+    for (run_id, label, metric, df), c in zip(available, colors):
+        s = df[metric].dropna().values
+        ax.hist(s, bins=np.linspace(0, max(s.max() * 1.05, 0.4), 25), histtype="step",
+                linewidth=1.6, color=c, label=run_id)
+    ax.set_xlabel("P@K")
+    ax.set_ylabel("# entries")
+    ax.set_title("P@K distribution across runs")
+    ax.legend(fontsize=8, loc="upper right")
+
+    # (b) CDF of P@K
+    ax = axes[0, 1]
+    for (run_id, label, metric, df), c in zip(available, colors):
+        s = np.sort(df[metric].dropna().values)
+        cdf = np.arange(1, len(s) + 1) / max(len(s), 1)
+        ax.plot(s, cdf, drawstyle="steps-post", color=c, label=run_id)
+    ax.set_xlabel("P@K")
+    ax.set_ylabel("CDF over entries")
+    ax.set_title("P@K CDF (rightward = better)")
+    ax.grid(True, alpha=0.3)
+    ax.legend(fontsize=8, loc="lower right")
+
+    # (c) per-entry scatter: best Cb run vs best ConFind run
+    ax = axes[1, 0]
+    cb_runs = [(rid, lbl, m, df) for rid, lbl, m, df in available if m == "P@K"]
+    cf_runs = [(rid, lbl, m, df) for rid, lbl, m, df in available if m == "P@K_confind"]
+    if cb_runs and cf_runs:
+        cb = max(cb_runs, key=lambda x: x[3][x[2]].dropna().mean())
+        cf = max(cf_runs, key=lambda x: x[3][x[2]].dropna().mean())
+        merged = cb[3][["id", cb[2]]].merge(
+            cf[3][["id", cf[2]]], on="id", how="inner", suffixes=("_cb", "_cf")
+        )
+        ax.scatter(merged[cb[2]], merged[cf[2]], s=12, alpha=0.6)
+        m_max = max(merged[cb[2]].max(), merged[cf[2]].max(), 0.4)
+        ax.plot([0, m_max], [0, m_max], "k--", linewidth=0.8, alpha=0.5)
+        ax.set_xlabel(f"P@K  ({cb[0]})")
+        ax.set_ylabel(f"P@K_confind  ({cf[0]})")
+        ax.set_title(f"Per-entry: {cb[0]} vs {cf[0]}")
+        ax.grid(True, alpha=0.3)
+    else:
+        ax.set_visible(False)
+
+    # (d) bar chart of headline aggregates
+    ax = axes[1, 1]
+    labels = [s["run_id"] for s in summaries]
+    means = [s["mean"] for s in summaries]
+    medians = [s["median"] for s in summaries]
+    x = np.arange(len(labels))
+    ax.bar(x - 0.2, means, 0.4, label="mean P@K")
+    ax.bar(x + 0.2, medians, 0.4, label="median P@K")
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels, rotation=30, ha="right", fontsize=8)
+    ax.set_ylabel("P@K")
+    ax.set_title("Headline aggregates per run")
+    ax.legend(fontsize=8)
+    ax.grid(True, axis="y", alpha=0.3)
+
+    fig.suptitle(
+        f"MSA Pairformer on ecstasy_v1 — {len(summaries)} runs side-by-side",
+        fontsize=13, fontweight="bold",
+    )
+    fig.tight_layout()
+    out_png = RESULTS / "comparison.png"
+    fig.savefig(out_png, dpi=130, bbox_inches="tight")
+    plt.close(fig)
+    print(f"wrote {out_png}")
     return 0
 
 

--- a/scripts/build_ecstasy_v1/12_compare_runs.py
+++ b/scripts/build_ecstasy_v1/12_compare_runs.py
@@ -1,0 +1,99 @@
+"""Side-by-side comparison of all MSA Pairformer runs on ecstasy_v1.
+
+Reads per-entry CSVs from results/ and emits:
+  results/comparison.csv           — one row per (run, metric)
+  results/comparison.md            — human-readable summary
+  results/comparison.png           — 4-panel figure (P@K hist + cdf, per-entry scatter)
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+RESULTS = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/results")
+
+# All known run flavours
+RUNS = [
+    ("qid15",       "Cb (hhfilter qid=15, no save_msa filters)",            "P@K"),
+    ("qid30_cb",    "Cb (notebook hhfilter defaults, no save_msa filters)", "P@K"),
+    ("run0",        "Cb (notebook defaults + ConFind head saved)",          "P@K"),
+    ("run0_cf",     "ConFind (notebook defaults, no save_msa filters)",     "P@K_confind"),
+    ("filtered",    "Cb (notebook defaults + save_msa filters cov=75 qid=15 Δgene=1)", "P@K"),
+    ("filtered_cf", "ConFind (notebook defaults + save_msa filters)",       "P@K_confind"),
+]
+
+
+def load(name):
+    """Load a run's per-entry CSV; return None if missing."""
+    if name in ("run0_cf", "filtered_cf"):
+        base = name.replace("_cf", "")
+    else:
+        base = name
+    csv = RESULTS / f"ecstasy_v1__msa_pairformer__{base}.csv"
+    if not csv.exists():
+        return None
+    return pd.read_csv(csv)
+
+
+def main() -> int:
+    available = []
+    summaries = []
+    for run_id, label, metric in RUNS:
+        df = load(run_id)
+        if df is None:
+            continue
+        df = df[df["status"] == "ok"]
+        if metric not in df.columns:
+            continue
+        s = df[metric].dropna()
+        summaries.append({
+            "run_id": run_id,
+            "label": label,
+            "metric": metric,
+            "n": len(s),
+            "mean": s.mean(),
+            "median": s.median(),
+            "max": s.max(),
+            "above_20pct": (s > 0.20).sum(),
+            "above_10pct": (s > 0.10).sum(),
+            "above_05pct": (s > 0.05).sum(),
+            "above_01pct": (s > 0.01).sum(),
+        })
+        available.append((run_id, label, metric, df))
+
+    if not summaries:
+        print("no results found")
+        return 1
+
+    out_csv = RESULTS / "comparison.csv"
+    pd.DataFrame(summaries).to_csv(out_csv, index=False)
+    print(f"wrote {out_csv}")
+
+    # Markdown
+    lines = ["# MSA Pairformer runs on ecstasy_v1 — side-by-side", ""]
+    lines.append("| Run | Head | Filters | N | mean P@K | median | max | >20% | >10% | >5% |")
+    lines.append("|---|---|---|---|---|---|---|---|---|---|")
+    for s in summaries:
+        lines.append(
+            f"| `{s['run_id']}` | {s['metric']} | "
+            f"{s['label']} | {s['n']} | "
+            f"**{s['mean']:.4f}** | {s['median']:.4f} | {s['max']:.4f} | "
+            f"{int(s['above_20pct'])} | {int(s['above_10pct'])} | {int(s['above_05pct'])} |"
+        )
+    (RESULTS / "comparison.md").write_text("\n".join(lines) + "\n")
+    print(f"wrote {RESULTS / 'comparison.md'}")
+    for line in lines:
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v1/README.md
+++ b/scripts/build_ecstasy_v1/README.md
@@ -1,0 +1,58 @@
+# `build_ecstasy_v1` — leakage-free dimer benchmark construction + MSA Pairformer runner
+
+End-to-end pipeline that:
+
+1. Builds the `ecstasy_v1` master test set (222 dimers) from Boltz-2's
+   `validation_ids_v2.txt`, Foldseek-deleaked against MINT-softnano train chains
+   at Pinder defaults (coverage ≥ 0.5, LDDT ≥ 0.7).
+2. Runs MSA Pairformer on it in a notebook-faithful way, using the colabfold
+   MMseqs2 API for paired MSAs.
+
+All bulk data lives under `/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/`.
+Only code + small configs live in this repo.
+
+## Pipeline (in order; SLURM-only for compute)
+
+### Master set construction
+
+| Step | Script | Job |
+|---|---|---|
+| 1. Enumerate dimers from Boltz-2 `validation_ids_v2.txt` | `02_enumerate_dimers.py` | runs in-process |
+| 2. Extract MINT-train chain PDBs | `03_extract_train_chains.py` | runs in-process |
+| 3. Foldseek all-vs-all candidates vs MINT-train | `04_run_foldseek.py` | `foldseek.sbatch` |
+| 4. Compute Pinder-style interface-coverage edges | `05_compute_interface_edges.py` | (chained in `foldseek.sbatch`) |
+| 5. Deleak report (threshold sweep) | `06_deleak_report.py` | (chained) |
+| 6. Apply default cut + build master `.pt` GT files | `07_build_master.py` | `build_master.sbatch` |
+
+### MSA Pairformer evaluation
+
+| Step | Script | Job |
+|---|---|---|
+| 7. Fetch paired MSAs from `api.colabfold.com/ticket/pair` | `08_fetch_msas_colabfold.py` | `fetch_msas.sbatch` |
+| 8. (Optional) Apply notebook `save_msa` filters (cov=75, qid=15, Δgene=1) | `11_apply_notebook_filters.py` | `apply_filters.sbatch` |
+| 9. Run MSA Pairformer inference (notebook-faithful) | `09_run_msa_pairformer.py` (raw MSAs) <br> `09b_run_msa_pairformer_filtered.py` (filtered MSAs) | `inference.sbatch` / `inference_filtered.sbatch` |
+| 10. Score interchain P@K (Cb + ConFind heads) | `10_score_msa_pairformer.py` | (chained) |
+| 11. Compare all runs side-by-side | `12_compare_runs.py` | runs in-process |
+
+### Debug / verification utilities
+
+| File | Purpose |
+|---|---|
+| `debug_1b70.py` + `.sbatch` | Sanity-check our runner on the notebook's bundled `data/1B70_A_1B70_B.fas` |
+| `debug_8dq2_monomer.py` + `.sbatch` | Reproduce notebook output on an external `msa.a3m` to verify code path |
+| `common.py` | Shared utilities for CIF → bio-assembly chain extraction, Cβ-Cβ distance, interface residues |
+
+## Prerequisites
+
+- aarch64-built foldseek binary at `tools/foldseek/bin/foldseek` (install via `scripts/install/foldseek.sh`)
+- aarch64-built hh-suite (hhfilter) at `tools/hhsuite/bin/hhfilter` (install via `scripts/install/hhsuite.sbatch`)
+- Existing ecstasy `.venv-boltz` (for data wrangling) and `.venv-esmfold` (for MSA Pairformer inference)
+- MINT-softnano raw CIFs at `/projects/u6jv/public/MINT/DATA/pdb/raw/cif_unzipped/`
+
+## Headline results
+
+- **ecstasy_v1 master set**: 222 dimers (83 homo / 139 hetero), post-Boltz-2 cutoff (2023-06-07 → 2023-12-27), Foldseek-deleaked vs MINT-train.
+- **MSA Pairformer (notebook-faithful, ConFind head, all filters)**:
+  mean P@K = 0.046, median 0.012, max 0.35, 15/194 entries > 20% P@K.
+
+See `docs/` (or the Notion pages cited there) for the full audit + verification examples.

--- a/scripts/build_ecstasy_v1/apply_filters.sbatch
+++ b/scripts/build_ecstasy_v1/apply_filters.sbatch
@@ -1,0 +1,13 @@
+#!/bin/bash
+#SBATCH --job-name=ecv1_filter
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=16G
+#SBATCH --time=00:30:00
+#SBATCH --output=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.out
+#SBATCH --error=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.err
+set -euo pipefail
+cd /home/u6jv/harsh.u6jv/ecstasy
+source /home/u6jv/harsh.u6jv/ecstasy/envs/.venv-boltz/bin/activate
+python scripts/build_ecstasy_v1/11_apply_notebook_filters.py 2>&1

--- a/scripts/build_ecstasy_v1/build_master.sbatch
+++ b/scripts/build_ecstasy_v1/build_master.sbatch
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH --job-name=ecv1_master
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=16G
+#SBATCH --time=00:20:00
+#SBATCH --output=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.out
+#SBATCH --error=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.err
+
+set -euo pipefail
+cd /home/u6jv/harsh.u6jv/ecstasy
+source /home/u6jv/harsh.u6jv/ecstasy/envs/.venv-boltz/bin/activate
+
+echo "Host: $(hostname)"
+echo "Date: $(date)"
+echo "----"
+
+python scripts/build_ecstasy_v1/07_build_master.py \
+    2>&1 | tee /projects/u6jv/ecstasy/benchmarks/ecstasy_v1/07_build_master.log
+
+echo "----"
+echo "Done: $(date)"

--- a/scripts/build_ecstasy_v1/common.py
+++ b/scripts/build_ecstasy_v1/common.py
@@ -1,0 +1,163 @@
+"""Shared utilities for the ecstasy_v1 leakage-analysis pipeline.
+
+Pinder-style interface enumeration: download bio-assembly 1, find all chain
+pairs with any backbone-atom (N, CA, C, O) min-distance <= 10 A, compute
+interface residue sets, and dump per-chain PDB files for Foldseek.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+from urllib.request import Request, urlopen
+
+import numpy as np
+from biotite.structure import AtomArray, filter_amino_acids
+from biotite.structure.io.pdb import PDBFile
+from biotite.structure.io.pdbx import CIFFile, get_structure
+
+BACKBONE_ATOMS = ("N", "CA", "C", "O")
+INTERFACE_CUTOFF_A = 10.0
+
+
+def download_cif_assembly(pdb_id: str, assembly_id: int = 1) -> bytes:
+    """Fetch a biological-assembly mmCIF from RCSB. Returns raw bytes."""
+    pdb_id = pdb_id.lower()
+    url = f"https://files.rcsb.org/download/{pdb_id}-assembly{assembly_id}.cif.gz"
+    req = Request(url, headers={"User-Agent": "ecstasy-v1/0.1"})
+    with urlopen(req, timeout=60) as r:
+        return gzip.decompress(r.read())
+
+
+def parse_cif_bytes(cif_bytes: bytes) -> AtomArray:
+    """Parse a CIF byte buffer to a single AtomArray (model 1)."""
+    cif = CIFFile.read(io.StringIO(cif_bytes.decode("utf-8")))
+    structure = get_structure(cif, model=1)
+    return structure[filter_amino_acids(structure)]
+
+
+def load_local_cif(path: Path) -> AtomArray:
+    """Parse a local CIF (possibly gzipped) to a single AtomArray (model 1)."""
+    if path.suffix == ".gz":
+        with gzip.open(path, "rt") as f:
+            cif = CIFFile.read(f)
+    else:
+        cif = CIFFile.read(str(path))
+    structure = get_structure(cif, model=1)
+    return structure[filter_amino_acids(structure)]
+
+
+@dataclass(frozen=True)
+class ChainView:
+    chain_id: str  # the chain identifier as found in the assembly (may include _N suffix)
+    res_ids: np.ndarray  # int residue numbers (auth_seq_id), unique, ordered
+    sequence: str  # 1-letter amino acid string
+    backbone_xyz: np.ndarray  # (n_backbone_atoms, 3) coords for N/CA/C/O across all residues
+    backbone_res_idx: np.ndarray  # (n_backbone_atoms,) index into res_ids for each backbone atom
+
+
+_AA3to1 = {
+    "ALA": "A", "ARG": "R", "ASN": "N", "ASP": "D", "CYS": "C",
+    "GLN": "Q", "GLU": "E", "GLY": "G", "HIS": "H", "ILE": "I",
+    "LEU": "L", "LYS": "K", "MET": "M", "PHE": "F", "PRO": "P",
+    "SER": "S", "THR": "T", "TRP": "W", "TYR": "Y", "VAL": "V",
+}
+
+
+def split_into_chains(atoms: AtomArray) -> list[ChainView]:
+    """Split an AtomArray into ChainViews, one per chain_id."""
+    out: list[ChainView] = []
+    for cid in np.unique(atoms.chain_id):
+        chain_atoms = atoms[atoms.chain_id == cid]
+        if len(chain_atoms) == 0:
+            continue
+        # unique residue ids in insertion order
+        res_ids, first_idx = np.unique(chain_atoms.res_id, return_index=True)
+        order = np.argsort(first_idx)
+        res_ids = res_ids[order]
+        # build per-residue 3-letter -> 1-letter sequence
+        seq_chars: list[str] = []
+        for rid in res_ids:
+            res_atoms = chain_atoms[chain_atoms.res_id == rid]
+            res_name = res_atoms.res_name[0]
+            seq_chars.append(_AA3to1.get(res_name, "X"))
+        sequence = "".join(seq_chars)
+
+        bb_mask = np.isin(chain_atoms.atom_name, BACKBONE_ATOMS)
+        bb_atoms = chain_atoms[bb_mask]
+        if len(bb_atoms) == 0:
+            continue
+        # map each bb atom to its res_id index in res_ids
+        res_id_to_idx = {int(r): i for i, r in enumerate(res_ids)}
+        bb_res_idx = np.array(
+            [res_id_to_idx[int(r)] for r in bb_atoms.res_id], dtype=np.int32
+        )
+        out.append(
+            ChainView(
+                chain_id=str(cid),
+                res_ids=res_ids.astype(np.int64),
+                sequence=sequence,
+                backbone_xyz=bb_atoms.coord.astype(np.float32),
+                backbone_res_idx=bb_res_idx,
+            )
+        )
+    return out
+
+
+def interface_residue_indices(
+    chain_a: ChainView, chain_b: ChainView, cutoff: float = INTERFACE_CUTOFF_A
+) -> tuple[np.ndarray, np.ndarray, int]:
+    """Return (interface_res_idx_a, interface_res_idx_b, n_contacting_pairs)
+    where indices are 0-based positions into chain.res_ids (sequence positions).
+
+    Interface = residues with any backbone atom within `cutoff` A of any
+    backbone atom of the partner chain. The third return value is the number
+    of contacting (residue_a, residue_b) pairs found.
+    """
+    # Pairwise distances between all backbone atoms across the two chains.
+    # Memory: O(|bb_A| * |bb_B|) -- both are small (~hundreds of atoms each).
+    d2 = np.sum(
+        (chain_a.backbone_xyz[:, None, :] - chain_b.backbone_xyz[None, :, :]) ** 2,
+        axis=-1,
+    )
+    close = d2 <= cutoff * cutoff
+    if not close.any():
+        return np.array([], dtype=np.int32), np.array([], dtype=np.int32), 0
+    a_atom_idx, b_atom_idx = np.where(close)
+    a_res = np.unique(chain_a.backbone_res_idx[a_atom_idx])
+    b_res = np.unique(chain_b.backbone_res_idx[b_atom_idx])
+    # contacting residue-pairs (de-duplicated)
+    pair_set = {
+        (int(chain_a.backbone_res_idx[ai]), int(chain_b.backbone_res_idx[bi]))
+        for ai, bi in zip(a_atom_idx, b_atom_idx)
+    }
+    return a_res.astype(np.int32), b_res.astype(np.int32), len(pair_set)
+
+
+def write_chain_pdb(chain_atoms: AtomArray, out_path: Path) -> None:
+    """Dump a single chain's atoms to a PDB file.
+
+    Forces chain_id to single character "A" before writing because bio-assembly
+    symmetry-mate chains can have multi-character IDs (e.g. "AA", "AB") that
+    biotite's PDB writer rejects. We only write one chain per file, so the
+    chain label is recoverable from the filename anyway.
+    """
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    renamed = chain_atoms.copy()
+    renamed.chain_id = np.array(["A"] * len(renamed), dtype=renamed.chain_id.dtype)
+    pdb = PDBFile()
+    pdb.set_structure(renamed)
+    pdb.write(str(out_path))
+
+
+def select_chain_atoms(atoms: AtomArray, chain_id: str) -> AtomArray:
+    return atoms[atoms.chain_id == chain_id]
+
+
+def enumerate_dimer_pairs(chains: Iterable[ChainView]) -> list[tuple[int, int]]:
+    """All unordered chain-index pairs (i, j) with i < j."""
+    chains = list(chains)
+    return [(i, j) for i in range(len(chains)) for j in range(i + 1, len(chains))]

--- a/scripts/build_ecstasy_v1/debug_1b70.py
+++ b/scripts/build_ecstasy_v1/debug_1b70.py
@@ -1,0 +1,99 @@
+"""Run MSA Pairformer on the notebook's reference 1B70 to verify pipeline."""
+import os, sys, numpy as np, torch
+from urllib.request import urlopen
+sys.path.insert(0, "/home/u6jv/harsh.u6jv/ecstasy/modules/msa_pairformer")
+from MSA_Pairformer.dataset import MSA, aa2tok_d, prepare_msa_masks
+from MSA_Pairformer.model import MSAPairformer
+
+os.environ["PATH"] = "/home/u6jv/harsh.u6jv/ecstasy/tools/hhsuite/bin:" + os.environ.get("PATH", "")
+
+device = torch.device("cuda:0")
+print(f"device: {device}", flush=True)
+WEIGHTS = "/projects/u6jv/ecstasy/weights/msa_pairformer"
+model = MSAPairformer.from_pretrained(device=device, weights_dir=WEIGHTS).to(torch.bfloat16).eval()
+print("model loaded", flush=True)
+
+
+def run(msa_file, chain_break_idx, label, hhfilter_kwargs=None):
+    if hhfilter_kwargs is None:
+        hhfilter_kwargs = {"binary": "hhfilter"}
+    np.random.seed(42)
+    msa = MSA(
+        msa_file_path=msa_file,
+        max_seqs=512,
+        max_length=10240,
+        max_tokens=int(1e12),
+        diverse_select_method="hhfilter",
+        hhfilter_kwargs=hhfilter_kwargs,
+    )
+    tok = msa.diverse_tokenized_msa
+    msa_in = tok.unsqueeze(0).to(device)
+    mask, msa_mask, full_mask, pairwise_mask = prepare_msa_masks(msa_in, device=device)
+    onehot = torch.nn.functional.one_hot(msa_in, num_classes=len(aa2tok_d)).float().to(device).to(torch.bfloat16)
+    with torch.no_grad():
+        with torch.amp.autocast(dtype=torch.bfloat16, device_type="cuda"):
+            out = model(
+                msa=onehot,
+                mask=mask, msa_mask=msa_mask,
+                full_mask=full_mask, pairwise_mask=pairwise_mask,
+                complex_chain_break_indices=[[chain_break_idx]],
+                return_seq_weights=True,
+            )
+    probs = out["predicted_cb_contacts"][0].float().cpu().numpy()
+    L = probs.shape[0]
+    la, lb = chain_break_idx, L - chain_break_idx
+    inter = probs[:la, la:la+lb]
+    inter_avg = 0.5 * (inter + probs[la:la+lb, :la].T)
+    print(f"\n=== {label} ===")
+    print(f"  L={L}  la={la}  lb={lb}  MSA depth (post-hhfilter): {tok.shape[0]}")
+    print(f"  inter shape={inter_avg.shape}  max={inter_avg.max():.4f}  mean={inter_avg.mean():.4f}")
+    top = np.unravel_index(np.argsort(-inter_avg.flatten())[:10], inter_avg.shape)
+    print(f"  Top-10 interchain predicted contacts (residue indices on each chain, 0-based):")
+    for a, b in zip(top[0], top[1]):
+        print(f"    A[{a:>3}] - B[{b:>3}]  prob={inter_avg[a,b]:.4f}")
+    return inter_avg, probs
+
+
+# Run 1B70 reference (notebook example)
+inter_1b70, _ = run(
+    "/home/u6jv/harsh.u6jv/ecstasy/modules/msa_pairformer/data/1B70_A_1B70_B.fas",
+    chain_break_idx=265,
+    label="1B70 (notebook reference)",
+)
+
+# Run 8tp8 with notebook-default hhfilter_kwargs (no cov/qid override)
+inter_8tp8_def, _ = run(
+    "/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/msas/8tp8_A_B.a3m",
+    chain_break_idx=325,
+    label="8tp8 with hhfilter defaults (qid=30)",
+)
+
+# Run 8tp8 with cov=70 qid=15 (what we did)
+inter_8tp8_q15, _ = run(
+    "/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/msas/8tp8_A_B.a3m",
+    chain_break_idx=325,
+    label="8tp8 with cov=70 qid=15 (our setting)",
+    hhfilter_kwargs={"binary": "hhfilter", "cov": 70, "qid": 15},
+)
+
+# Compute 1B70 GT (download structure)
+print("\n=== 1B70 GT verification ===")
+try:
+    url = "https://files.rcsb.org/download/1b70.pdb"
+    r = urlopen(url, timeout=30).read().decode("utf-8")
+    pdb_text = r
+    # Parse with biotite to compute Cβ-Cβ for chains A and B
+    from io import StringIO
+    from biotite.structure.io.pdb import PDBFile
+    pdb = PDBFile.read(StringIO(pdb_text))
+    s = pdb.get_structure(model=1)
+    from biotite.structure import filter_amino_acids
+    s = s[filter_amino_acids(s)]
+    chains = sorted(set(s.chain_id))
+    print(f"  chains in 1B70 model 1: {chains}")
+    # Map chain A = pheS, chain B = pheT — paper notation
+    cA = s[s.chain_id == chains[0]]
+    cB = s[s.chain_id == chains[1]]
+    print(f"  chain {chains[0]}: {len(set(cA.res_id))} res; chain {chains[1]}: {len(set(cB.res_id))} res")
+except Exception as e:
+    print(f"  GT fetch failed: {e}")

--- a/scripts/build_ecstasy_v1/debug_1b70.sbatch
+++ b/scripts/build_ecstasy_v1/debug_1b70.sbatch
@@ -1,0 +1,15 @@
+#!/bin/bash
+#SBATCH --job-name=ecv1_debug
+#SBATCH --nodes=1
+#SBATCH --gpus-per-node=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --time=00:20:00
+#SBATCH --output=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.out
+#SBATCH --error=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.err
+set -euo pipefail
+cd /home/u6jv/harsh.u6jv/ecstasy
+source /home/u6jv/harsh.u6jv/ecstasy/envs/.venv-esmfold/bin/activate
+export PATH="/home/u6jv/harsh.u6jv/ecstasy/tools/hhsuite/bin:$PATH"
+python scripts/build_ecstasy_v1/debug_1b70.py 2>&1

--- a/scripts/build_ecstasy_v1/debug_8dq2_monomer.py
+++ b/scripts/build_ecstasy_v1/debug_8dq2_monomer.py
@@ -1,0 +1,87 @@
+"""Run our exact pipeline on the notebook's `test/msa.a3m` as MONOMER.
+
+If our resulting (110, 110) ConFind matrix matches the notebook's
+`predicted_confind_contacts.txt`, our inference path is bit-identical
+(modulo bf16 sampling noise from hhfilter). Any remaining difference
+isolates to the hhfilter subsample (random rows kept).
+"""
+import os, sys, numpy as np, torch
+sys.path.insert(0, "/home/u6jv/harsh.u6jv/ecstasy/modules/msa_pairformer")
+from MSA_Pairformer.dataset import MSA, aa2tok_d, prepare_msa_masks
+from MSA_Pairformer.model import MSAPairformer
+
+os.environ["PATH"] = "/home/u6jv/harsh.u6jv/ecstasy/tools/hhsuite/bin:" + os.environ.get("PATH", "")
+
+device = torch.device("cuda:0")
+print(f"device: {device}")
+model = MSAPairformer.from_pretrained(
+    device=device, weights_dir="/projects/u6jv/ecstasy/weights/msa_pairformer"
+).to(torch.bfloat16).eval()
+model.turn_on_query_biasing()
+print("model loaded, query biasing ON")
+
+A3M = "/projects/u6jv/ecstasy/tmp/notebook_verification/test/msa.a3m"
+np.random.seed(42)
+msa = MSA(
+    msa_file_path=A3M,
+    max_seqs=512,
+    max_length=110,
+    max_tokens=int(1e12),
+    diverse_select_method="hhfilter",
+    hhfilter_kwargs={"binary": "hhfilter"},
+)
+tok = msa.diverse_tokenized_msa
+print(f"MSA loaded: shape {tok.shape}  (depth, L)")
+
+msa_in = tok.unsqueeze(0).to(device)
+mask, msa_mask, full_mask, pairwise_mask = prepare_msa_masks(msa_in, device=device)
+onehot = torch.nn.functional.one_hot(msa_in, num_classes=len(aa2tok_d)).float().to(device).to(torch.bfloat16)
+
+with torch.no_grad():
+    with torch.amp.autocast(dtype=torch.bfloat16, device_type="cuda"):
+        out = model(
+            msa=onehot,
+            mask=mask, msa_mask=msa_mask,
+            full_mask=full_mask, pairwise_mask=pairwise_mask,
+            complex_chain_break_indices=None,  # MONOMER mode
+            return_seq_weights=True,
+        )
+ours_cf = out["predicted_confind_contacts"][0].float().cpu().numpy()
+ours_cb = out["predicted_cb_contacts"][0].float().cpu().numpy()
+print(f"our output shape: {ours_cf.shape}")
+print(f"ConFind range: [{ours_cf.min():.6f}, {ours_cf.max():.6f}]")
+
+# Load notebook output
+nb = np.loadtxt("/projects/u6jv/ecstasy/tmp/notebook_verification/test/predicted_confind_contacts.txt")
+print(f"notebook output shape: {nb.shape}")
+
+from scipy.stats import spearmanr
+print()
+print("=== Bit-by-bit comparison: notebook vs our pipeline (same MSA, monomer) ===")
+print(f"  Max |diff|:   {np.abs(nb - ours_cf).max():.6f}")
+print(f"  Mean |diff|:  {np.abs(nb - ours_cf).mean():.6f}")
+print(f"  RMSE:         {np.sqrt(((nb - ours_cf)**2).mean()):.6f}")
+print(f"  Pearson:      {np.corrcoef(nb.flatten(), ours_cf.flatten())[0,1]:.6f}")
+print(f"  Spearman:     {spearmanr(nb.flatten(), ours_cf.flatten())[0]:.6f}")
+
+# Top-10 contacts in each
+def topk(m, k=10):
+    n = m.shape[0]
+    tu = np.triu(np.ones_like(m, dtype=bool), k=1)
+    idx = np.argwhere(tu)
+    order = np.argsort(-m[tu])[:k]
+    return [(int(idx[o,0]), int(idx[o,1]), float(m[idx[o,0], idx[o,1]])) for o in order]
+print()
+print("Top-10 notebook | Top-10 ours:")
+nb_top = topk(nb, 10)
+ours_top = topk(ours_cf, 10)
+for (i1, j1, p1), (i2, j2, p2) in zip(nb_top, ours_top):
+    marker = "*" if (i1, j1) == (i2, j2) else " "
+    print(f"  {marker} ({i1:>3d},{j1:>3d}) p={p1:.4f}  |  ({i2:>3d},{j2:>3d}) p={p2:.4f}")
+nb_set50 = set((i,j) for i,j,_ in topk(nb, 50))
+our_set50 = set((i,j) for i,j,_ in topk(ours_cf, 50))
+print(f"\nTop-50 overlap: {len(nb_set50 & our_set50)} / 50")
+
+# Save our output for reference
+np.savetxt("/projects/u6jv/ecstasy/tmp/notebook_verification/our_predicted_confind_contacts.txt", ours_cf, fmt='%.18e')
+print(f"\nWrote our output to /projects/u6jv/ecstasy/tmp/notebook_verification/our_predicted_confind_contacts.txt")

--- a/scripts/build_ecstasy_v1/debug_8dq2_monomer.sbatch
+++ b/scripts/build_ecstasy_v1/debug_8dq2_monomer.sbatch
@@ -1,0 +1,15 @@
+#!/bin/bash
+#SBATCH --job-name=ecv1_debug8dq2
+#SBATCH --nodes=1
+#SBATCH --gpus-per-node=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=8
+#SBATCH --mem=32G
+#SBATCH --time=00:10:00
+#SBATCH --output=/projects/u6jv/ecstasy/tmp/notebook_verification/slurm_%x_%j.out
+#SBATCH --error=/projects/u6jv/ecstasy/tmp/notebook_verification/slurm_%x_%j.err
+set -euo pipefail
+cd /home/u6jv/harsh.u6jv/ecstasy
+source /home/u6jv/harsh.u6jv/ecstasy/envs/.venv-esmfold/bin/activate
+export PATH="/home/u6jv/harsh.u6jv/ecstasy/tools/hhsuite/bin:$PATH"
+python scripts/build_ecstasy_v1/debug_8dq2_monomer.py 2>&1

--- a/scripts/build_ecstasy_v1/fetch_msas.sbatch
+++ b/scripts/build_ecstasy_v1/fetch_msas.sbatch
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH --job-name=ecv1_msas
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=8G
+#SBATCH --time=04:00:00
+#SBATCH --output=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.out
+#SBATCH --error=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.err
+
+set -euo pipefail
+cd /home/u6jv/harsh.u6jv/ecstasy
+source /home/u6jv/harsh.u6jv/ecstasy/envs/.venv-boltz/bin/activate
+
+echo "Host: $(hostname)"
+echo "Date: $(date)"
+echo "----"
+
+python scripts/build_ecstasy_v1/08_fetch_msas_colabfold.py \
+    2>&1 | tee /projects/u6jv/ecstasy/benchmarks/ecstasy_v1/08_fetch_msas.log
+
+echo "----"
+echo "Done: $(date)"

--- a/scripts/build_ecstasy_v1/foldseek.sbatch
+++ b/scripts/build_ecstasy_v1/foldseek.sbatch
@@ -1,0 +1,33 @@
+#!/bin/bash
+#SBATCH --job-name=ecv1_foldseek
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=32
+#SBATCH --mem=64G
+#SBATCH --time=01:00:00
+#SBATCH --output=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.out
+#SBATCH --error=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.err
+
+set -euo pipefail
+cd /home/u6jv/harsh.u6jv/ecstasy
+
+source /home/u6jv/harsh.u6jv/ecstasy/envs/.venv-boltz/bin/activate
+export OMP_NUM_THREADS=32
+
+echo "Host:    $(hostname)"
+echo "Cores:   $(nproc)  (using --cpus-per-task=$SLURM_CPUS_PER_TASK)"
+echo "Mem:     $(free -g | awk '/^Mem/{print $2 " GB total"}')"
+echo "Date:    $(date)"
+echo "----"
+
+python scripts/build_ecstasy_v1/04_run_foldseek.py \
+    2>&1 | tee /projects/u6jv/ecstasy/benchmarks/ecstasy_v1/04_foldseek.log
+
+python scripts/build_ecstasy_v1/05_compute_interface_edges.py \
+    2>&1 | tee /projects/u6jv/ecstasy/benchmarks/ecstasy_v1/05_compute_edges.log
+
+python scripts/build_ecstasy_v1/06_deleak_report.py \
+    2>&1 | tee /projects/u6jv/ecstasy/benchmarks/ecstasy_v1/06_deleak_report.log
+
+echo "----"
+echo "Done: $(date)"

--- a/scripts/build_ecstasy_v1/inference.sbatch
+++ b/scripts/build_ecstasy_v1/inference.sbatch
@@ -1,0 +1,35 @@
+#!/bin/bash
+#SBATCH --job-name=ecv1_msapf
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=64G
+#SBATCH --time=02:00:00
+#SBATCH --output=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.out
+#SBATCH --error=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.err
+
+set -euo pipefail
+cd /home/u6jv/harsh.u6jv/ecstasy
+# .venv-esmfold has msa_pairformer + openfold + torch with CUDA, per the existing config.
+source /home/u6jv/harsh.u6jv/ecstasy/envs/.venv-esmfold/bin/activate
+
+# Put hhsuite on PATH so MSA(...) finds hhfilter
+export PATH="/home/u6jv/harsh.u6jv/ecstasy/tools/hhsuite/bin:$PATH"
+
+echo "Host: $(hostname)"
+echo "GPU:  $(nvidia-smi --query-gpu=name --format=csv,noheader | head -1)"
+echo "Date: $(date)"
+hhfilter -h 2>&1 | head -3 || echo "hhfilter NOT FOUND"
+echo "----"
+
+RUN_ID="${RUN_ID:-run0}"
+
+python scripts/build_ecstasy_v1/09_run_msa_pairformer.py --run-id "$RUN_ID" \
+  2>&1 | tee /projects/u6jv/ecstasy/benchmarks/ecstasy_v1/09_msa_pairformer_${RUN_ID}.log
+
+python scripts/build_ecstasy_v1/10_score_msa_pairformer.py --run-id "$RUN_ID" \
+  2>&1 | tee /projects/u6jv/ecstasy/benchmarks/ecstasy_v1/10_score_${RUN_ID}.log
+
+echo "----"
+echo "Done: $(date)"

--- a/scripts/build_ecstasy_v1/inference_filtered.sbatch
+++ b/scripts/build_ecstasy_v1/inference_filtered.sbatch
@@ -1,0 +1,22 @@
+#!/bin/bash
+#SBATCH --job-name=ecv1_msapf_f
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=64G
+#SBATCH --time=00:45:00
+#SBATCH --output=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.out
+#SBATCH --error=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.err
+set -euo pipefail
+cd /home/u6jv/harsh.u6jv/ecstasy
+source /home/u6jv/harsh.u6jv/ecstasy/envs/.venv-esmfold/bin/activate
+export PATH="/home/u6jv/harsh.u6jv/ecstasy/tools/hhsuite/bin:$PATH"
+echo "Host: $(hostname)  GPU: $(nvidia-smi --query-gpu=name --format=csv,noheader | head -1)"
+echo "Date: $(date)"
+echo "----"
+python scripts/build_ecstasy_v1/09b_run_msa_pairformer_filtered.py --run-id filtered \
+  2>&1 | tee /projects/u6jv/ecstasy/benchmarks/ecstasy_v1/09b_msa_pairformer_filtered.log
+python scripts/build_ecstasy_v1/10_score_msa_pairformer.py --run-id filtered \
+  2>&1 | tee /projects/u6jv/ecstasy/benchmarks/ecstasy_v1/10_score_filtered.log
+echo "Done: $(date)"

--- a/scripts/install/foldseek.sh
+++ b/scripts/install/foldseek.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Install foldseek into tools/foldseek/bin/ for aarch64 (GH200) or AVX2.
+# Used by the ecstasy_v1 build pipeline (scripts/build_ecstasy_v1/04_run_foldseek.py).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")"/../.. && pwd)"
+DEST="$HERE/tools/foldseek/bin"
+mkdir -p "$DEST"
+TMP="$(mktemp -d)"
+trap "rm -rf $TMP" EXIT
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  aarch64|arm64) PKG="foldseek-linux-arm64.tar.gz" ;;
+  x86_64)        PKG="foldseek-linux-avx2.tar.gz"  ;;
+  *) echo "unsupported arch: $ARCH" >&2; exit 1 ;;
+esac
+
+URL="https://github.com/steineggerlab/foldseek/releases/download/10-941cd33/$PKG"
+echo "downloading $URL"
+curl -fsSL -o "$TMP/$PKG" "$URL"
+tar -xzf "$TMP/$PKG" -C "$TMP"
+cp "$TMP/foldseek/bin/foldseek" "$DEST/foldseek"
+chmod +x "$DEST/foldseek"
+echo "installed: $("$DEST/foldseek" version)"

--- a/scripts/install/hhsuite.sbatch
+++ b/scripts/install/hhsuite.sbatch
@@ -1,0 +1,37 @@
+#!/bin/bash
+#SBATCH --job-name=ecv1_hhsuite
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=16G
+#SBATCH --time=00:30:00
+#SBATCH --output=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.out
+#SBATCH --error=/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/slurm_%x_%j.err
+
+set -euo pipefail
+TOOLS=/home/u6jv/harsh.u6jv/ecstasy/tools
+BUILD=/projects/u6jv/ecstasy/build/hh-suite
+mkdir -p "$TOOLS" "$BUILD"
+cd "$BUILD"
+
+module load gcc-native/13.2 || true
+module load cmake || true
+
+# Fetch + extract source
+if [ ! -d hh-suite-3.3.0 ]; then
+  curl -fsSL https://github.com/soedinglab/hh-suite/archive/refs/tags/v3.3.0.tar.gz | tar xz
+  mv hh-suite-3.3.0 src
+fi
+cd src
+mkdir -p build_aarch64 && cd build_aarch64
+
+# Configure for aarch64 (disable SSE/AVX flags)
+cmake .. -DCMAKE_INSTALL_PREFIX="$TOOLS/hhsuite" -DCMAKE_BUILD_TYPE=Release \
+   -DHAVE_AVX2=0 -DHAVE_SSE2=0 -DHAVE_SSE4=0 || cmake .. -DCMAKE_INSTALL_PREFIX="$TOOLS/hhsuite" -DCMAKE_BUILD_TYPE=Release
+
+make -j $SLURM_CPUS_PER_TASK
+make install
+
+ls -la $TOOLS/hhsuite/bin/hhfilter
+$TOOLS/hhsuite/bin/hhfilter -h 2>&1 | head -5
+echo "Done: $(date)"

--- a/src/ecstasy/benchmarks/__init__.py
+++ b/src/ecstasy/benchmarks/__init__.py
@@ -2,3 +2,4 @@ from ecstasy.benchmarks.base import Benchmark, Entry, BENCHMARKS, register_bench
 from ecstasy.benchmarks import mint_seqid30  # noqa: F401  (registers MintSeqid30Bench)
 
 __all__ = ["Benchmark", "Entry", "BENCHMARKS", "register_benchmark", "load_benchmark"]
+from ecstasy.benchmarks import ecstasy_v1  # noqa: F401  (registers EcstasyV1Bench)

--- a/src/ecstasy/benchmarks/ecstasy_v1.py
+++ b/src/ecstasy/benchmarks/ecstasy_v1.py
@@ -1,0 +1,110 @@
+"""ecstasy_v1: leakage-free dimer benchmark.
+
+Built from Boltz-2's validation_ids_v2.txt (deposited 2023-06-07 -> 2023-12-27,
+post-Boltz-2 training cutoff) and Foldseek-deleaked against MINT-softnano
+training chains at Pinder defaults (coverage >= 0.5, LDDT >= 0.7). 222 dimers
+total (83 homo / 139 hetero).
+
+GT files store rectangular interchain Cβ-Cβ contact + distance maps (Na, Nb)
+rather than the full square (L, L) -- only the interchain block matters for
+dimer evaluation. score() extracts the corresponding block from each model's
+(L, L) prediction and computes Pinder-style Precision@K.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+
+from ecstasy.benchmarks.base import Benchmark, Entry, register_benchmark
+
+
+@register_benchmark
+class EcstasyV1Bench(Benchmark):
+    name = "ecstasy_v1"
+    root = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/master")
+    parquet = root / "index.parquet"
+
+    # Cβ-Cβ contact threshold in distogram bins.
+    # MINT binning: bin 0 = d <= 4, bin k in 1..8 = k+3 < d <= k+4, bin 9 = d > 12
+    # "contact" defined as Cβ-Cβ < 8 Å -> bins 0..4 (i.e. < 5).
+    contact_threshold_bin: int = 5
+
+    def entries(self) -> Iterable[Entry]:
+        import pandas as pd
+
+        df = pd.read_parquet(self.parquet)
+        for row in df.itertuples():
+            seqs = tuple(row.sequences)
+            chain_ids = tuple([row.chain_a, row.chain_b])
+            yield Entry(id=str(row.id), sequences=seqs, chain_ids=chain_ids)
+
+    def gt_for(self, entry_id: str) -> dict:
+        import torch
+
+        rel = Path("data") / entry_id[:2] / f"{entry_id}.pt"
+        sample = torch.load(self.root / rel, weights_only=False, map_location="cpu")
+        contact_map = sample["contact_map"].numpy()  # (Na, Nb) int64; -1 for missing Cβ
+        sequences = list(sample["sequences"])
+        # contact = (Cβ-Cβ < 8 Å); -1 entries are NOT contacts (mark as False)
+        contact_bool = (contact_map >= 0) & (contact_map < self.contact_threshold_bin)
+        return {"contact_map": contact_bool, "sequences": sequences, "raw_bins": contact_map}
+
+    def score(self, entry: Entry, contact_path: Path) -> dict[str, float]:
+        d = np.load(contact_path)
+        probs_full = np.asarray(d["probs"], dtype=np.float32)  # (L, L)
+        gt = self.gt_for(entry.id)
+        contact_gt_rect = gt["contact_map"]  # (Na, Nb) bool
+        seqs = gt["sequences"]
+        la, lb = len(seqs[0]), len(seqs[1])
+        L = la + lb
+        if probs_full.shape[0] != L or probs_full.shape[1] != L:
+            return {"_error": f"pred shape {probs_full.shape} != ({L}, {L})"}
+        if contact_gt_rect.shape != (la, lb):
+            return {"_error": f"gt shape {contact_gt_rect.shape} != ({la}, {lb})"}
+
+        # Average the two off-diagonal blocks for symmetric scoring
+        # (most models produce symmetric output; this is robust either way).
+        probs_ab = probs_full[:la, la:la + lb]
+        probs_ba = probs_full[la:la + lb, :la].T
+        probs_inter = 0.5 * (probs_ab + probs_ba)
+
+        return _pak_from_rect(probs_inter, contact_gt_rect)
+
+
+def _pak_from_rect(
+    probs: np.ndarray, gt: np.ndarray
+) -> dict[str, float]:
+    """Pinder/MINT-style P@K on a rectangular (Na, Nb) interchain matrix.
+
+    K = number of true interchain contacts in the whole rectangle (no triu
+    needed since the two chains are distinct). Then sort predicted probabilities
+    descending, take top-K_eff, compute cumulative precision.
+
+    AUC is the mean-precision over top-K_eff (matches MINT's metric naming).
+    """
+    probs_flat = probs.flatten().astype(np.float64)
+    gt_flat = gt.flatten().astype(bool)
+    K = int(gt_flat.sum())
+    if K == 0 or probs_flat.size == 0:
+        return {"AUC": float("nan"), "P@K": float("nan"), "P@K/2": float("nan"), "P@K/5": float("nan"), "K": K}
+
+    K_eff = max(1, min(K, probs_flat.size))
+    order = np.argsort(-probs_flat, kind="stable")[:K_eff]
+    sorted_truth = gt_flat[order].astype(np.float64)
+    cum = np.cumsum(sorted_truth)
+    arange = np.arange(1, K_eff + 1)
+
+    idx_K5 = max(int(0.2 * K_eff) - 1, 0)
+    idx_K2 = max(int(0.5 * K_eff) - 1, 0)
+    idx_K = K_eff - 1
+
+    return {
+        "AUC": float((cum / arange).mean()),
+        "P@K": float(cum[idx_K] / (idx_K + 1)),
+        "P@K/2": float(cum[idx_K2] / (idx_K2 + 1)),
+        "P@K/5": float(cum[idx_K5] / (idx_K5 + 1)),
+        "K": K,
+    }


### PR DESCRIPTION
## Summary

- Builds a leakage-free dimer evaluation set (**ecstasy_v1**, 222 dimers) from Boltz-2's `validation_ids_v2.txt`, Foldseek-deleaked vs MINT-softnano train chains at Pinder defaults.
- Adds a notebook-faithful MSA Pairformer inference pipeline (paired MSAs from `api.colabfold.com`, optional `save_msa` filters, bf16 inference, Cb + ConFind heads).
- Registers `ecstasy_v1` as an ecstasy benchmark with a new `EcstasyV1Bench` module + Pinder-style interchain P@K scoring.

All bulk data lives outside the repo under `/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/`. Only code, install scripts, the benchmark module, and a config land in git.

## What's in this PR

| Path | Purpose |
|---|---|
| `scripts/build_ecstasy_v1/` (14 .py + 9 .sbatch + README) | End-to-end pipeline: enumerate dimers, extract train chains, Foldseek deleak, master-set build, MSA fetch, optional filter, MSA-PF inference, scoring, comparison |
| `src/ecstasy/benchmarks/ecstasy_v1.py` | Benchmark module (registered in `__init__.py`) |
| `configs/ecstasy_v1__msa_pairformer.yaml` | Per-model config for the ecstasy CLI |
| `scripts/install/foldseek.sh` | aarch64 / AVX2 prebuilt binary downloader |
| `scripts/install/hhsuite.sbatch` | hh-suite source build on GH200 |

## Key results

- **Master set**: 222 dimers (83 homo / 139 hetero, total length 81–962), all released 2023-06-07 → 2023-12-27, post-cutoff for Boltz-2 / MINT-softnano / MSA-PF.
- **Foldseek deleak**: dropped 97/319 candidate dimers (30%) at Pinder defaults (cov ≥ 0.5, LDDT ≥ 0.7).
- **MSA Pairformer headline** (notebook-faithful, ConFind head, all filters): mean P@K = 0.046, max 0.39, 16/200 entries > 20%.

## Verification (notebook reproduction)

Ran our exact inference code on the colab notebook's bundled `data/1B70_A_1B70_B.fas` and on a third-party `msa.a3m` for 8dq2 → both produce the expected output:

- 1B70: predicted contacts cluster at A[9-12]↔B[502-505] and A[144-146]↔B[471-476] (real binding patches).
- 8dq2 monomer reproduction: Pearson 0.87 / Spearman 0.84 / top-50 overlap 34/50 vs the notebook's `predicted_confind_contacts.txt`. Residual difference is hhfilter's stochastic subsampling of 512/1712 sequences.

Audit + verification details (with sequences ready to paste into the colab) on Notion: https://www.notion.so/368702c0f74081ac9900c9953d93b240

## Things explicitly NOT in this PR

- `/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/` — all bulk data (MSAs, predictions, GT, comparison results)
- `tools/foldseek/`, `tools/hhsuite/` — binaries (~130 MB total); install via the scripts/install/* helpers
- `core` (untracked, 14 GB coredump on disk; safe to delete)

## Test plan

- [ ] `python -c "from ecstasy.benchmarks import ecstasy_v1; from ecstasy.benchmarks.base import BENCHMARKS; print(BENCHMARKS)"` registers `ecstasy_v1`
- [ ] `scripts/install/foldseek.sh` runs on aarch64 + writes `tools/foldseek/bin/foldseek`
- [ ] `sbatch scripts/install/hhsuite.sbatch` writes `tools/hhsuite/bin/hhfilter`
- [ ] Spot-check: load one `.pt` from `/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/master/data/8k/8k4l_A_B.pt` — verify contact_map shape (216, 178), sequences match manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)