### PR TITLE
feat: ecstasy_v2 build pipeline (post-Boltz-2-cutoff dimers, dual-deleak)

### DIFF
--- a/scripts/build_ecstasy_v2/01_query_rcsb_candidates.py
+++ b/scripts/build_ecstasy_v2/01_query_rcsb_candidates.py
@@ -1,0 +1,176 @@
+"""Query RCSB Search API for ecstasy_v2 candidate PDB IDs.
+
+Selection criteria (mirrors the v2 issue spec):
+  - initial_release_date >= 2023-06-01 (Boltz-2 training cutoff)
+  - experimental method: X-ray diffraction
+  - polymer_entity_count_protein >= 2
+
+Also pulls per-entry metadata (deposit_date, release_date, resolution,
+method, n_protein_entities) so downstream scripts don't need a second
+RCSB roundtrip for the same IDs.
+
+Outputs:
+  candidates/pdb_ids.txt              # newline-separated IDs (lowercase)
+  candidates/rcsb_metadata.parquet    # same schema as v1 val_v2_metadata.parquet
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.request import Request, urlopen
+
+import pandas as pd
+
+OUT_ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v2/candidates")
+IDS_PATH = OUT_ROOT / "pdb_ids.txt"
+META_PATH = OUT_ROOT / "rcsb_metadata.parquet"
+
+RELEASE_CUTOFF = "2023-06-01"  # Boltz-2 training cutoff
+SEARCH_URL = "https://search.rcsb.org/rcsbsearch/v2/query"
+GRAPHQL_URL = "https://data.rcsb.org/graphql"
+
+
+def search_pdb_ids() -> list[str]:
+    """Paginate RCSB Search API for entries matching the v2 criteria."""
+    query = {
+        "query": {
+            "type": "group",
+            "logical_operator": "and",
+            "nodes": [
+                {
+                    "type": "terminal",
+                    "service": "text",
+                    "parameters": {
+                        "attribute": "rcsb_accession_info.initial_release_date",
+                        "operator": "greater_or_equal",
+                        "value": f"{RELEASE_CUTOFF}T00:00:00Z",
+                    },
+                },
+                {
+                    "type": "terminal",
+                    "service": "text",
+                    "parameters": {
+                        "attribute": "exptl.method",
+                        "operator": "exact_match",
+                        "value": "X-RAY DIFFRACTION",
+                    },
+                },
+                {
+                    "type": "terminal",
+                    "service": "text",
+                    "parameters": {
+                        "attribute": "rcsb_entry_info.polymer_entity_count_protein",
+                        "operator": "greater_or_equal",
+                        "value": 2,
+                    },
+                },
+            ],
+        },
+        "return_type": "entry",
+        "request_options": {
+            "paginate": {"start": 0, "rows": 10000},
+            "results_content_type": ["experimental"],
+            "sort": [{"sort_by": "rcsb_accession_info.initial_release_date", "direction": "asc"}],
+        },
+    }
+
+    all_ids: list[str] = []
+    start = 0
+    page = 10000
+    while True:
+        query["request_options"]["paginate"] = {"start": start, "rows": page}
+        req = Request(
+            SEARCH_URL,
+            data=json.dumps(query).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        with urlopen(req, timeout=120) as r:
+            data = json.load(r)
+        total = data.get("total_count", 0)
+        results = data.get("result_set") or []
+        ids = [item["identifier"].lower() for item in results]
+        all_ids.extend(ids)
+        print(f"  fetched {len(all_ids)}/{total} IDs", flush=True)
+        if len(all_ids) >= total or not results:
+            break
+        start += page
+    # dedupe preserving order
+    seen = set()
+    out = []
+    for pid in all_ids:
+        if pid not in seen:
+            seen.add(pid)
+            out.append(pid)
+    return out
+
+
+def fetch_rcsb_metadata(pdb_ids: list[str]) -> pd.DataFrame:
+    BATCH = 50
+    rows: list[dict] = []
+    for i in range(0, len(pdb_ids), BATCH):
+        batch = pdb_ids[i : i + BATCH]
+        ids_str = '","'.join(batch)
+        query = (
+            '{ entries(entry_ids: ["' + ids_str + '"]) {'
+            " rcsb_id"
+            " rcsb_accession_info { deposit_date initial_release_date }"
+            " exptl { method }"
+            " rcsb_entry_info { resolution_combined polymer_entity_count_protein }"
+            " } }"
+        )
+        req = Request(
+            GRAPHQL_URL,
+            data=json.dumps({"query": query}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        with urlopen(req, timeout=120) as r:
+            data = json.load(r)
+        for e in data["data"]["entries"] or []:
+            if e is None:
+                continue
+            method = (e.get("exptl") or [{}])[0].get("method") if e.get("exptl") else None
+            res_list = (e.get("rcsb_entry_info") or {}).get("resolution_combined") or []
+            resolution = res_list[0] if res_list else None
+            n_prot = (e.get("rcsb_entry_info") or {}).get("polymer_entity_count_protein")
+            ai = e["rcsb_accession_info"] or {}
+            rows.append(
+                {
+                    "pdb_id": e["rcsb_id"].lower(),
+                    "deposit_date": (ai.get("deposit_date") or "")[:10],
+                    "release_date": (ai.get("initial_release_date") or "")[:10],
+                    "method": method,
+                    "resolution": resolution,
+                    "n_protein_entities": n_prot,
+                }
+            )
+        print(f"  metadata: {len(rows)}/{len(pdb_ids)}", flush=True)
+    return pd.DataFrame(rows)
+
+
+def main() -> int:
+    OUT_ROOT.mkdir(parents=True, exist_ok=True)
+
+    print(f"Searching RCSB for X-ray protein entries released >= {RELEASE_CUTOFF} ...")
+    pdb_ids = search_pdb_ids()
+    print(f"  total candidate PDB IDs: {len(pdb_ids)}")
+
+    IDS_PATH.write_text("\n".join(pdb_ids) + "\n")
+    print(f"  wrote {IDS_PATH}")
+
+    print(f"Fetching per-entry metadata for {len(pdb_ids)} IDs ...")
+    meta_df = fetch_rcsb_metadata(pdb_ids)
+    meta_df.to_parquet(META_PATH, index=False)
+    print(f"  wrote {META_PATH}  ({len(meta_df)} rows)")
+
+    print()
+    print("=== summary ===")
+    print(f"PDB IDs:            {len(pdb_ids)}")
+    print(f"release-date range: {meta_df['release_date'].min()} .. {meta_df['release_date'].max()}")
+    print(f"method counts:      {meta_df['method'].value_counts().to_dict()}")
+    print(f"n_protein_entities: min={meta_df['n_protein_entities'].min()} max={meta_df['n_protein_entities'].max()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v2/02_enumerate_dimers.py
+++ b/scripts/build_ecstasy_v2/02_enumerate_dimers.py
@@ -1,0 +1,216 @@
+"""Enumerate candidate dimers from the v2 RCSB candidate list (post-2023-06-01).
+
+Mirrors `build_ecstasy_v1/02_enumerate_dimers.py` end-to-end. The only
+differences are:
+  - input PDB IDs come from `01_query_rcsb_candidates.py` output
+  - output paths live under `/projects/u6jv/ecstasy/benchmarks/ecstasy_v2/`
+  - the RCSB metadata parquet is reused from step 01 (no second roundtrip)
+
+Filters (identical to v1):
+  - X-ray, resolution <= 3.5 Å
+  - min chain length 40 res
+  - dimer total length <= 1200 res
+  - >= 3 inter-chain backbone-atom contacts (<= 10 Å)
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import traceback
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+
+import pandas as pd
+
+from ecstasy.structure import (  # noqa: E402
+    download_cif_assembly,
+    enumerate_dimer_pairs,
+    interface_residue_indices,
+    parse_cif_bytes,
+    select_chain_atoms,
+    split_into_chains,
+    write_chain_pdb,
+)
+
+OUT_ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v2/candidates")
+IDS_PATH = OUT_ROOT / "pdb_ids.txt"
+META_PATH = OUT_ROOT / "rcsb_metadata.parquet"
+CHAINS_DIR = OUT_ROOT / "chains"
+DIMERS_PATH = OUT_ROOT / "dimers.parquet"
+PER_ENTRY_LOG = OUT_ROOT / "per_entry_log.parquet"
+
+MIN_CHAIN_LEN = 40
+MAX_DIMER_LEN = 1200
+MIN_CONTACTS = 3
+ASSEMBLY_ID = 1
+
+
+def passes_quality(meta_row: pd.Series) -> tuple[bool, str]:
+    if meta_row["method"] not in ("X-RAY DIFFRACTION",):
+        return False, f"method={meta_row['method']}"
+    if meta_row["resolution"] is None or meta_row["resolution"] > 3.5:
+        return False, f"resolution={meta_row['resolution']}"
+    return True, ""
+
+
+def process_one(args: tuple[str, dict]) -> dict:
+    pdb_id, _meta = args
+    pdb_id = pdb_id.lower()
+    out: dict = {
+        "pdb_id": pdb_id,
+        "status": "ok",
+        "n_chains": 0,
+        "n_dimers": 0,
+        "dimer_rows": [],
+        "chain_writes": [],
+        "error": None,
+    }
+    try:
+        cif_bytes = download_cif_assembly(pdb_id, ASSEMBLY_ID)
+        atoms = parse_cif_bytes(cif_bytes)
+        chains = split_into_chains(atoms)
+        out["n_chains"] = len(chains)
+        if len(chains) < 2:
+            out["status"] = "skip_too_few_chains"
+            return out
+
+        short_idxs = {i for i, c in enumerate(chains) if len(c.res_ids) < MIN_CHAIN_LEN}
+
+        for i, j in enumerate_dimer_pairs(chains):
+            if i in short_idxs or j in short_idxs:
+                continue
+            c_a, c_b = chains[i], chains[j]
+            total_len = len(c_a.res_ids) + len(c_b.res_ids)
+            if total_len > MAX_DIMER_LEN:
+                continue
+            ia, ib, npair = interface_residue_indices(c_a, c_b)
+            if npair < MIN_CONTACTS:
+                continue
+            out["dimer_rows"].append(
+                {
+                    "pdb_id": pdb_id,
+                    "assembly_id": ASSEMBLY_ID,
+                    "chain_a": c_a.chain_id,
+                    "chain_b": c_b.chain_id,
+                    "len_a": int(len(c_a.res_ids)),
+                    "len_b": int(len(c_b.res_ids)),
+                    "seq_a": c_a.sequence,
+                    "seq_b": c_b.sequence,
+                    "interface_idx_a": ia.tolist(),
+                    "interface_idx_b": ib.tolist(),
+                    "n_interface_residues_a": int(len(ia)),
+                    "n_interface_residues_b": int(len(ib)),
+                    "n_contact_pairs": int(npair),
+                    "is_homodimer": bool(c_a.sequence == c_b.sequence),
+                }
+            )
+
+        kept_chain_ids = {r["chain_a"] for r in out["dimer_rows"]} | {
+            r["chain_b"] for r in out["dimer_rows"]
+        }
+        for c in chains:
+            if c.chain_id not in kept_chain_ids:
+                continue
+            chain_atoms = select_chain_atoms(atoms, c.chain_id)
+            chain_path = CHAINS_DIR / f"{pdb_id}_{ASSEMBLY_ID}_{c.chain_id}.pdb"
+            write_chain_pdb(chain_atoms, chain_path)
+            out["chain_writes"].append(
+                {
+                    "pdb_id": pdb_id,
+                    "chain_id": c.chain_id,
+                    "path": str(chain_path),
+                    "length": int(len(c.res_ids)),
+                    "sequence": c.sequence,
+                }
+            )
+
+        out["n_dimers"] = len(out["dimer_rows"])
+    except HTTPError as e:
+        out["status"] = "http_error"
+        out["error"] = f"{e.code} {e.reason}"
+    except URLError as e:
+        out["status"] = "url_error"
+        out["error"] = str(e.reason)
+    except Exception as e:  # noqa: BLE001
+        out["status"] = "parse_error"
+        out["error"] = f"{type(e).__name__}: {e}\n{traceback.format_exc(limit=2)}"
+    return out
+
+
+def main() -> int:
+    CHAINS_DIR.mkdir(parents=True, exist_ok=True)
+
+    pdb_ids = [ln.strip().lower() for ln in IDS_PATH.read_text().splitlines() if ln.strip()]
+    print(f"Loaded {len(pdb_ids)} candidate PDB IDs from {IDS_PATH}")
+
+    meta_df = pd.read_parquet(META_PATH)
+    print(f"Loaded metadata for {len(meta_df)} entries from {META_PATH}")
+
+    keep_mask = meta_df.apply(lambda r: passes_quality(r)[0], axis=1)
+    kept_ids = meta_df.loc[keep_mask, "pdb_id"].tolist()
+    rejected_n = len(meta_df) - len(kept_ids)
+    print(
+        f"  quality filter: kept {len(kept_ids)}/{len(meta_df)} "
+        f"({rejected_n} rejected by method/resolution)"
+    )
+
+    meta_by_id = {r["pdb_id"]: r.to_dict() for _, r in meta_df.iterrows()}
+
+    print(f"Enumerating dimers for {len(kept_ids)} PDB IDs (parallel) ...")
+    all_dimers: list[dict] = []
+    all_chains: list[dict] = []
+    per_entry: list[dict] = []
+    nworkers = min(16, mp.cpu_count())
+    with ProcessPoolExecutor(max_workers=nworkers) as pool:
+        futures = {pool.submit(process_one, (pid, meta_by_id[pid])): pid for pid in kept_ids}
+        for n, fut in enumerate(as_completed(futures), 1):
+            res = fut.result()
+            all_dimers.extend(res["dimer_rows"])
+            all_chains.extend(res["chain_writes"])
+            per_entry.append(
+                {
+                    "pdb_id": res["pdb_id"],
+                    "status": res["status"],
+                    "n_chains": res["n_chains"],
+                    "n_dimers": res["n_dimers"],
+                    "error": res["error"],
+                }
+            )
+            if n % 200 == 0 or n == len(futures):
+                ok = sum(1 for p in per_entry if p["status"] == "ok")
+                ndim = sum(p["n_dimers"] for p in per_entry)
+                print(f"  [{n}/{len(futures)}]  ok={ok}  total_dimers={ndim}", flush=True)
+
+    dimers_df = pd.DataFrame(all_dimers)
+    chains_df = pd.DataFrame(all_chains)
+    per_entry_df = pd.DataFrame(per_entry)
+    dimers_df.to_parquet(DIMERS_PATH, index=False)
+    chains_df.to_parquet(OUT_ROOT / "chains_manifest.parquet", index=False)
+    per_entry_df.to_parquet(PER_ENTRY_LOG, index=False)
+
+    print()
+    print(f"  wrote {DIMERS_PATH}            ({len(dimers_df)} dimers)")
+    print(f"  wrote chains_manifest.parquet  ({len(chains_df)} chain PDBs)")
+    print(f"  wrote {PER_ENTRY_LOG}          (per-PDB processing log)")
+    print()
+    print("=== summary ===")
+    print(f"PDB IDs queried:          {len(pdb_ids)}")
+    print(f"  rejected by quality:    {rejected_n}")
+    print(f"  processed:              {len(kept_ids)}")
+    print(f"  status counts:          {per_entry_df['status'].value_counts().to_dict()}")
+    print(f"Dimers (post-filter):     {len(dimers_df)}")
+    if len(dimers_df):
+        print(
+            f"  homodimers:             {int(dimers_df['is_homodimer'].sum())} "
+            f"({100 * dimers_df['is_homodimer'].mean():.1f}%)"
+        )
+        print(
+            f"  total residues range:   [{(dimers_df['len_a'] + dimers_df['len_b']).min()}, "
+            f"{(dimers_df['len_a'] + dimers_df['len_b']).max()}]"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v2/03a_extract_mentos_chains.py
+++ b/scripts/build_ecstasy_v2/03a_extract_mentos_chains.py
@@ -1,0 +1,176 @@
+"""Make Mentos-train (formerly MINT-train, PDB <= 2021-09-30) chain PDBs
+available under the v2 layout.
+
+If `build_ecstasy_v1/03_extract_train_chains.py` has already populated
+`ecstasy_v1/train_db/mint_train_chains/`, we just symlink that directory
+into the v2 tree so Foldseek can reuse the same DB without redoing the
+~25k-entry CIF parse. Otherwise we extract from scratch with identical
+logic to v1.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import traceback
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+
+import pandas as pd
+
+from ecstasy.structure import (  # noqa: E402
+    load_local_cif,
+    select_chain_atoms,
+    split_into_chains,
+    write_chain_pdb,
+)
+
+MENTOS_SPLIT_PARQUET = Path(
+    "/projects/u6jv/public/MINT/DATA/pdb/processed/splits/seq_id_30/index.parquet"
+)
+MENTOS_CIF_ROOT = Path("/projects/u6jv/public/MINT/DATA/pdb/raw/cif_unzipped")
+
+V1_TRAIN_DIR = Path(
+    "/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/train_db/mint_train_chains"
+)
+V1_MANIFEST = Path(
+    "/projects/u6jv/ecstasy/benchmarks/ecstasy_v1/train_db/mint_train_chains_manifest.parquet"
+)
+
+OUT_ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v2/train_db")
+CHAINS_DIR = OUT_ROOT / "mentos_train_chains"
+INDEX_PATH = OUT_ROOT / "mentos_train_chains_manifest.parquet"
+MISSING_PATH = OUT_ROOT / "mentos_train_missing.parquet"
+
+MIN_CHAIN_LEN = 40
+DATE_CUTOFF = "2021-09-30"
+
+
+def try_reuse_v1() -> bool:
+    if not V1_TRAIN_DIR.is_dir() or not V1_MANIFEST.exists():
+        return False
+    OUT_ROOT.mkdir(parents=True, exist_ok=True)
+    if CHAINS_DIR.exists() or CHAINS_DIR.is_symlink():
+        print(f"  {CHAINS_DIR} already exists; leaving as-is")
+    else:
+        os.symlink(V1_TRAIN_DIR, CHAINS_DIR)
+        print(f"  symlinked {CHAINS_DIR} -> {V1_TRAIN_DIR}")
+    if not INDEX_PATH.exists():
+        df = pd.read_parquet(V1_MANIFEST)
+        df.to_parquet(INDEX_PATH, index=False)
+        print(f"  copied manifest -> {INDEX_PATH}  ({len(df)} rows)")
+    return True
+
+
+def build_cif_index() -> dict[str, Path]:
+    print(f"Building CIF index under {MENTOS_CIF_ROOT} ...")
+    idx: dict[str, Path] = {}
+    for bucket in sorted(MENTOS_CIF_ROOT.iterdir()):
+        if not bucket.is_dir():
+            continue
+        for cif in bucket.glob("*.cif"):
+            idx[cif.stem.lower()] = cif
+    print(f"  indexed {len(idx)} CIFs")
+    return idx
+
+
+def process_one(args: tuple[str, str]) -> dict:
+    pdb_id, cif_path_s = args
+    cif_path = Path(cif_path_s)
+    out: dict = {
+        "pdb_id": pdb_id,
+        "status": "ok",
+        "n_chains_written": 0,
+        "chains": [],
+        "error": None,
+    }
+    try:
+        atoms = load_local_cif(cif_path)
+        chains = split_into_chains(atoms)
+        for c in chains:
+            if len(c.res_ids) < MIN_CHAIN_LEN:
+                continue
+            chain_atoms = select_chain_atoms(atoms, c.chain_id)
+            chain_path = CHAINS_DIR / f"{pdb_id}_{c.chain_id}.pdb"
+            write_chain_pdb(chain_atoms, chain_path)
+            out["chains"].append(
+                {
+                    "pdb_id": pdb_id,
+                    "chain_id": c.chain_id,
+                    "path": str(chain_path),
+                    "length": int(len(c.res_ids)),
+                    "sequence": c.sequence,
+                }
+            )
+        out["n_chains_written"] = len(out["chains"])
+        if out["n_chains_written"] == 0:
+            out["status"] = "skip_no_long_chains"
+    except Exception as e:  # noqa: BLE001
+        out["status"] = "parse_error"
+        out["error"] = f"{type(e).__name__}: {e}\n{traceback.format_exc(limit=2)}"
+    return out
+
+
+def extract_from_scratch() -> int:
+    CHAINS_DIR.mkdir(parents=True, exist_ok=True)
+    split_df = pd.read_parquet(MENTOS_SPLIT_PARQUET)
+    train_ids = sorted(split_df.loc[split_df["split"] == "train", "id"].unique().tolist())
+    train_ids = [pid.lower() for pid in train_ids]
+    print(f"Mentos-train PDB IDs (seq_id_30): {len(train_ids)}")
+
+    cif_idx = build_cif_index()
+    matched, missing = [], []
+    for pid in train_ids:
+        p = cif_idx.get(pid)
+        if p is None:
+            missing.append(pid)
+        else:
+            matched.append((pid, str(p)))
+    print(f"  matched: {len(matched)}  missing: {len(missing)}")
+    if missing:
+        pd.DataFrame({"pdb_id": missing}).to_parquet(MISSING_PATH, index=False)
+
+    print(f"Extracting chains (parallel) ...")
+    all_chains: list[dict] = []
+    statuses: list[dict] = []
+    nworkers = min(32, mp.cpu_count())
+    with ProcessPoolExecutor(max_workers=nworkers) as pool:
+        futures = {pool.submit(process_one, m): m[0] for m in matched}
+        for n, fut in enumerate(as_completed(futures), 1):
+            res = fut.result()
+            all_chains.extend(res["chains"])
+            statuses.append(
+                {
+                    "pdb_id": res["pdb_id"],
+                    "status": res["status"],
+                    "n_chains": res["n_chains_written"],
+                    "error": res["error"],
+                }
+            )
+            if n % 1000 == 0 or n == len(futures):
+                ok = sum(1 for s in statuses if s["status"] == "ok")
+                nch = sum(s["n_chains"] for s in statuses)
+                print(f"  [{n}/{len(futures)}]  ok={ok}  chains_written={nch}", flush=True)
+
+    chains_df = pd.DataFrame(all_chains)
+    status_df = pd.DataFrame(statuses)
+    chains_df.to_parquet(INDEX_PATH, index=False)
+    status_df.to_parquet(OUT_ROOT / "mentos_train_per_entry_log.parquet", index=False)
+    print(f"  wrote {INDEX_PATH}  ({len(chains_df)} chain PDBs)")
+    print(f"  unique chain sequences: {chains_df['sequence'].nunique()}")
+    print(f"  status: {status_df['status'].value_counts().to_dict()}")
+    return 0
+
+
+def main() -> int:
+    OUT_ROOT.mkdir(parents=True, exist_ok=True)
+    print("Trying to reuse v1's mint_train_chains/ ...")
+    if try_reuse_v1():
+        print("  reused v1 outputs")
+        return 0
+    print("  v1 outputs unavailable; extracting from scratch")
+    return extract_from_scratch()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v2/03b_extract_boltz2_delta_chains.py
+++ b/scripts/build_ecstasy_v2/03b_extract_boltz2_delta_chains.py
@@ -1,0 +1,241 @@
+"""Extract per-chain PDBs for the "Boltz-2 delta" — PDB entries released
+between the Mentos cutoff (2021-09-30) and the Boltz-2 cutoff (2023-06-01).
+
+The Boltz-2 paper does not publish an explicit training chain list, so we
+approximate the Boltz-2 training chain set as
+
+    boltz2_train_chains := mentos_train_chains  ∪  delta_chains
+
+This is a strict superset of the actual Boltz-2 training set (it includes
+every PDB released up to the cutoff, irrespective of clustering), and is
+therefore conservative for the purpose of deleaking ecstasy_v2 against
+Boltz-2 leakage.
+
+This script handles only the delta (2021-10-01 .. 2023-05-31, inclusive).
+Step 04 (`04_run_foldseek.py`) builds the union DB by createdb'ing both
+chain directories together.
+
+For each delta PDB ID we download the asymmetric-unit CIF from RCSB
+(`files.rcsb.org/download/<id>.cif.gz`) — this matches what Mentos used
+upstream (no bio-assembly expansion). We apply the same chain-length
+filter (>= 40 res) as the v1 train-chain extraction.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import json
+import multiprocessing as mp
+import traceback
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import pandas as pd
+
+from ecstasy.structure import (  # noqa: E402
+    parse_cif_bytes,
+    select_chain_atoms,
+    split_into_chains,
+    write_chain_pdb,
+)
+
+OUT_ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v2/train_db")
+DELTA_IDS_PATH = OUT_ROOT / "boltz2_delta_ids.txt"
+DELTA_META_PATH = OUT_ROOT / "boltz2_delta_metadata.parquet"
+CHAINS_DIR = OUT_ROOT / "boltz2_delta_chains"
+INDEX_PATH = OUT_ROOT / "boltz2_delta_chains_manifest.parquet"
+PER_ENTRY_LOG = OUT_ROOT / "boltz2_delta_per_entry_log.parquet"
+
+# Inclusive bounds. The Mentos cutoff is 2021-09-30, so the delta starts
+# the next day. The Boltz-2 cutoff is 2023-06-01 (use < not <=).
+DELTA_START = "2021-10-01"
+DELTA_END_EXCLUSIVE = "2023-06-01"
+
+MIN_CHAIN_LEN = 40
+SEARCH_URL = "https://search.rcsb.org/rcsbsearch/v2/query"
+GRAPHQL_URL = "https://data.rcsb.org/graphql"
+CIF_URL_TMPL = "https://files.rcsb.org/download/{pdb_id}.cif.gz"
+
+
+def search_delta_ids() -> list[str]:
+    """All PDB entries released in [DELTA_START, DELTA_END_EXCLUSIVE) with
+    >= 1 protein entity (we don't restrict to X-ray here — the Boltz-2 train
+    set spans methods)."""
+    query = {
+        "query": {
+            "type": "group",
+            "logical_operator": "and",
+            "nodes": [
+                {
+                    "type": "terminal",
+                    "service": "text",
+                    "parameters": {
+                        "attribute": "rcsb_accession_info.initial_release_date",
+                        "operator": "greater_or_equal",
+                        "value": f"{DELTA_START}T00:00:00Z",
+                    },
+                },
+                {
+                    "type": "terminal",
+                    "service": "text",
+                    "parameters": {
+                        "attribute": "rcsb_accession_info.initial_release_date",
+                        "operator": "less",
+                        "value": f"{DELTA_END_EXCLUSIVE}T00:00:00Z",
+                    },
+                },
+                {
+                    "type": "terminal",
+                    "service": "text",
+                    "parameters": {
+                        "attribute": "rcsb_entry_info.polymer_entity_count_protein",
+                        "operator": "greater_or_equal",
+                        "value": 1,
+                    },
+                },
+            ],
+        },
+        "return_type": "entry",
+        "request_options": {
+            "paginate": {"start": 0, "rows": 10000},
+            "results_content_type": ["experimental"],
+            "sort": [
+                {"sort_by": "rcsb_accession_info.initial_release_date", "direction": "asc"}
+            ],
+        },
+    }
+    all_ids: list[str] = []
+    start = 0
+    page = 10000
+    while True:
+        query["request_options"]["paginate"] = {"start": start, "rows": page}
+        req = Request(
+            SEARCH_URL,
+            data=json.dumps(query).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+        )
+        with urlopen(req, timeout=120) as r:
+            data = json.load(r)
+        total = data.get("total_count", 0)
+        results = data.get("result_set") or []
+        all_ids.extend(item["identifier"].lower() for item in results)
+        print(f"  fetched {len(all_ids)}/{total} delta IDs", flush=True)
+        if len(all_ids) >= total or not results:
+            break
+        start += page
+    seen = set()
+    out = []
+    for pid in all_ids:
+        if pid not in seen:
+            seen.add(pid)
+            out.append(pid)
+    return out
+
+
+def download_cif(pdb_id: str) -> bytes:
+    url = CIF_URL_TMPL.format(pdb_id=pdb_id.lower())
+    with urlopen(url, timeout=60) as r:
+        data = r.read()
+    with gzip.open(io.BytesIO(data)) as gz:
+        return gz.read()
+
+
+def process_one(pdb_id: str) -> dict:
+    pdb_id = pdb_id.lower()
+    out: dict = {
+        "pdb_id": pdb_id,
+        "status": "ok",
+        "n_chains_written": 0,
+        "chains": [],
+        "error": None,
+    }
+    try:
+        cif_bytes = download_cif(pdb_id)
+        atoms = parse_cif_bytes(cif_bytes)
+        chains = split_into_chains(atoms)
+        for c in chains:
+            if len(c.res_ids) < MIN_CHAIN_LEN:
+                continue
+            chain_atoms = select_chain_atoms(atoms, c.chain_id)
+            chain_path = CHAINS_DIR / f"{pdb_id}_{c.chain_id}.pdb"
+            write_chain_pdb(chain_atoms, chain_path)
+            out["chains"].append(
+                {
+                    "pdb_id": pdb_id,
+                    "chain_id": c.chain_id,
+                    "path": str(chain_path),
+                    "length": int(len(c.res_ids)),
+                    "sequence": c.sequence,
+                }
+            )
+        out["n_chains_written"] = len(out["chains"])
+        if out["n_chains_written"] == 0:
+            out["status"] = "skip_no_long_chains"
+    except HTTPError as e:
+        out["status"] = "http_error"
+        out["error"] = f"{e.code} {e.reason}"
+    except URLError as e:
+        out["status"] = "url_error"
+        out["error"] = str(e.reason)
+    except Exception as e:  # noqa: BLE001
+        out["status"] = "parse_error"
+        out["error"] = f"{type(e).__name__}: {e}\n{traceback.format_exc(limit=2)}"
+    return out
+
+
+def main() -> int:
+    OUT_ROOT.mkdir(parents=True, exist_ok=True)
+    CHAINS_DIR.mkdir(parents=True, exist_ok=True)
+
+    if DELTA_IDS_PATH.exists():
+        delta_ids = [
+            ln.strip().lower() for ln in DELTA_IDS_PATH.read_text().splitlines() if ln.strip()
+        ]
+        print(f"Reusing cached delta ID list: {len(delta_ids)} IDs from {DELTA_IDS_PATH}")
+    else:
+        print(f"Querying RCSB for PDB entries released in [{DELTA_START}, {DELTA_END_EXCLUSIVE}) ...")
+        delta_ids = search_delta_ids()
+        DELTA_IDS_PATH.write_text("\n".join(delta_ids) + "\n")
+        print(f"  wrote {DELTA_IDS_PATH}  ({len(delta_ids)} IDs)")
+
+    print(f"Downloading + extracting chains for {len(delta_ids)} delta PDB IDs (parallel) ...")
+    all_chains: list[dict] = []
+    statuses: list[dict] = []
+    # I/O-bound (network + CIF parsing); use more workers than CPU count.
+    nworkers = min(64, (mp.cpu_count() or 8) * 4)
+    with ProcessPoolExecutor(max_workers=nworkers) as pool:
+        futures = {pool.submit(process_one, pid): pid for pid in delta_ids}
+        for n, fut in enumerate(as_completed(futures), 1):
+            res = fut.result()
+            all_chains.extend(res["chains"])
+            statuses.append(
+                {
+                    "pdb_id": res["pdb_id"],
+                    "status": res["status"],
+                    "n_chains": res["n_chains_written"],
+                    "error": res["error"],
+                }
+            )
+            if n % 500 == 0 or n == len(futures):
+                ok = sum(1 for s in statuses if s["status"] == "ok")
+                nch = sum(s["n_chains"] for s in statuses)
+                print(f"  [{n}/{len(futures)}]  ok={ok}  chains_written={nch}", flush=True)
+
+    chains_df = pd.DataFrame(all_chains)
+    status_df = pd.DataFrame(statuses)
+    chains_df.to_parquet(INDEX_PATH, index=False)
+    status_df.to_parquet(PER_ENTRY_LOG, index=False)
+    print()
+    print(f"  wrote {INDEX_PATH}  ({len(chains_df)} chain PDBs)")
+    print(f"  wrote {PER_ENTRY_LOG}")
+    if len(chains_df):
+        print(f"  unique chain sequences (delta-only): {chains_df['sequence'].nunique()}")
+    print(f"  status counts: {status_df['status'].value_counts().to_dict()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v2/04_run_foldseek.py
+++ b/scripts/build_ecstasy_v2/04_run_foldseek.py
@@ -1,0 +1,126 @@
+"""Run Foldseek easy-search twice: candidates vs Mentos-train AND vs Boltz-2-train.
+
+Two-job approach (rather than a single union DB) so we keep per-source
+attribution: downstream reports can answer "this dimer was dropped because
+of a Mentos hit / a Boltz-2 hit / both."
+
+The Boltz-2 train DB is built by createdb'ing the union of Mentos chains
++ the Boltz-2 delta chains (see `03b_extract_boltz2_delta_chains.py`).
+
+Outputs:
+  foldseek_hits_mentos.m8
+  foldseek_hits_boltz2.m8
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+FOLDSEEK = Path("/home/u6jv/harsh.u6jv/ecstasy/tools/foldseek/bin/foldseek")
+ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v2")
+CANDIDATES_DIR = ROOT / "candidates" / "chains"
+MENTOS_DIR = ROOT / "train_db" / "mentos_train_chains"
+BOLTZ2_DELTA_DIR = ROOT / "train_db" / "boltz2_delta_chains"
+
+DB_DIR = ROOT / "foldseek_dbs"
+TMP_DIR = ROOT / "foldseek_tmp"
+HITS_MENTOS = ROOT / "foldseek_hits_mentos.m8"
+HITS_BOLTZ2 = ROOT / "foldseek_hits_boltz2.m8"
+
+FORMAT_OUTPUT = "query,target,lddt,qstart,qend,qlen,tstart,tend,tlen,alnlen,evalue"
+
+NTHREADS = int(
+    os.environ.get("SLURM_CPUS_PER_TASK")
+    or os.environ.get("OMP_NUM_THREADS")
+    or 16
+)
+
+
+def run(cmd: list[str]) -> None:
+    print(" $ " + " ".join(str(c) for c in cmd), flush=True)
+    subprocess.run(cmd, check=True)
+
+
+def createdb_if_missing(name: str, src_dirs: list[Path]) -> Path:
+    """Create a Foldseek DB from one or more directories of PDBs.
+
+    Foldseek's `createdb` accepts multiple input paths; passing both
+    `mentos_train_chains/` and `boltz2_delta_chains/` builds the union DB
+    in one shot.
+    """
+    db_path = DB_DIR / name
+    sentinel = DB_DIR / name  # foldseek's main index file uses the bare name
+    if sentinel.exists():
+        print(f"  reusing existing DB at {db_path}")
+        return db_path
+    for d in src_dirs:
+        if not d.is_dir():
+            raise SystemExit(f"ERROR: source dir {d} missing")
+    cmd = [str(FOLDSEEK), "createdb", *[str(d) for d in src_dirs], str(db_path),
+           "--threads", str(NTHREADS)]
+    run(cmd)
+    return db_path
+
+
+def easy_search(query_dir: Path, target_db: Path, hits_path: Path) -> None:
+    if TMP_DIR.exists():
+        shutil.rmtree(TMP_DIR)
+    TMP_DIR.mkdir(parents=True, exist_ok=True)
+    run([
+        str(FOLDSEEK),
+        "easy-search",
+        str(query_dir),
+        str(target_db),
+        str(hits_path),
+        str(TMP_DIR),
+        "-s", "11.0",
+        "-e", "0.05",
+        "--alignment-type", "2",
+        "--max-seqs", "1000",
+        "--threads", str(NTHREADS),
+        "--format-output", FORMAT_OUTPUT,
+    ])
+    print(f"  wrote {hits_path}  ({hits_path.stat().st_size / 1e6:.1f} MB)")
+    with hits_path.open() as f:
+        n_hits = sum(1 for _ in f)
+    print(f"  {n_hits} hit rows")
+
+
+def main() -> int:
+    DB_DIR.mkdir(parents=True, exist_ok=True)
+
+    cand_count = len(list(CANDIDATES_DIR.glob("*.pdb")))
+    mentos_count = len(list(MENTOS_DIR.glob("*.pdb"))) if MENTOS_DIR.is_dir() else 0
+    delta_count = len(list(BOLTZ2_DELTA_DIR.glob("*.pdb"))) if BOLTZ2_DELTA_DIR.is_dir() else 0
+    print(f"Candidate chain PDBs:           {cand_count}")
+    print(f"Mentos-train chain PDBs:        {mentos_count}")
+    print(f"Boltz-2 delta chain PDBs:       {delta_count}")
+    print(f"Boltz-2 train DB total (union): {mentos_count + delta_count}")
+    print(f"Threads:                        {NTHREADS}")
+    if cand_count == 0 or mentos_count == 0 or delta_count == 0:
+        print("ERROR: empty input dir(s)", file=sys.stderr)
+        return 1
+
+    # 1. Candidates DB (queries — same for both searches)
+    cand_db = createdb_if_missing("candidates_db", [CANDIDATES_DIR])
+    # 2. Mentos-train DB
+    mentos_db = createdb_if_missing("mentos_train_db", [MENTOS_DIR])
+    # 3. Boltz-2 train DB = Mentos ∪ delta
+    boltz2_db = createdb_if_missing("boltz2_train_db", [MENTOS_DIR, BOLTZ2_DELTA_DIR])
+
+    print("\n=== Search: candidates vs Mentos-train ===")
+    easy_search(CANDIDATES_DIR, mentos_db, HITS_MENTOS)
+
+    print("\n=== Search: candidates vs Boltz-2-train (union) ===")
+    easy_search(CANDIDATES_DIR, boltz2_db, HITS_BOLTZ2)
+
+    _ = cand_db  # avoid lint
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v2/05_compute_interface_edges.py
+++ b/scripts/build_ecstasy_v2/05_compute_interface_edges.py
@@ -1,0 +1,141 @@
+"""Compute Pinder-style interface-coverage edges from BOTH Foldseek hit files.
+
+Same per-edge math as v1's 05 (interface ∩ aligned-query-range / interface),
+applied to each (candidate_chain, train_chain) hit, but expanded into one
+row per (dimer, chain-side, source DB).
+
+The `source` column tags each edge as "mentos" or "boltz2".
+
+Outputs:
+  all_edges_with_coverage.parquet   # everything, both sources
+  interface_edges.parquet           # filtered to coverage >= 0.5 (Pinder default)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v2")
+CANDIDATES_DIR = ROOT / "candidates"
+HITS_MENTOS = ROOT / "foldseek_hits_mentos.m8"
+HITS_BOLTZ2 = ROOT / "foldseek_hits_boltz2.m8"
+OUT_PATH = ROOT / "interface_edges.parquet"
+ALL_EDGES_PATH = ROOT / "all_edges_with_coverage.parquet"
+
+COVERAGE_THRESHOLD = 0.5
+
+HIT_COLS = [
+    "query", "target", "lddt",
+    "qstart", "qend", "qlen",
+    "tstart", "tend", "tlen",
+    "alnlen", "evalue",
+]
+
+
+def _strip_ext(name: str) -> str:
+    return name[:-4] if name.endswith(".pdb") else name
+
+
+def load_hits(path: Path, source: str) -> pd.DataFrame:
+    if not path.exists():
+        print(f"  WARNING: {path} missing — skipping {source} source")
+        return pd.DataFrame(columns=[*HIT_COLS, "source"])
+    df = pd.read_csv(path, sep="\t", header=None, names=HIT_COLS)
+    df["query"] = df["query"].map(_strip_ext)
+    df["target"] = df["target"].map(_strip_ext)
+    df = df[df["query"] != df["target"]].reset_index(drop=True)
+    df["source"] = source
+    print(f"  {source}: {len(df)} hits after self-hit drop")
+    return df
+
+
+def main() -> int:
+    print("Loading Foldseek hits ...")
+    hits_m = load_hits(HITS_MENTOS, "mentos")
+    hits_b = load_hits(HITS_BOLTZ2, "boltz2")
+    hits = pd.concat([hits_m, hits_b], ignore_index=True)
+    print(f"  total hits across sources: {len(hits)}")
+
+    print(f"Loading candidate dimers from {CANDIDATES_DIR}/dimers.parquet ...")
+    dimers = pd.read_parquet(CANDIDATES_DIR / "dimers.parquet")
+    print(f"  {len(dimers)} candidate dimers")
+
+    cand_long: list[dict] = []
+    for di, d in dimers.iterrows():
+        key_a = f"{d['pdb_id']}_{d['assembly_id']}_{d['chain_a']}"
+        key_b = f"{d['pdb_id']}_{d['assembly_id']}_{d['chain_b']}"
+        cand_long.append(
+            {
+                "dimer_idx": di,
+                "pdb_id": d["pdb_id"],
+                "chain_label": d["chain_a"],
+                "partner_label": d["chain_b"],
+                "side": "a",
+                "query_key": key_a,
+                "interface_idx": np.array(d["interface_idx_a"], dtype=np.int32),
+                "n_interface": int(d["n_interface_residues_a"]),
+                "chain_len": int(d["len_a"]),
+                "is_homodimer": bool(d["is_homodimer"]),
+            }
+        )
+        cand_long.append(
+            {
+                "dimer_idx": di,
+                "pdb_id": d["pdb_id"],
+                "chain_label": d["chain_b"],
+                "partner_label": d["chain_a"],
+                "side": "b",
+                "query_key": key_b,
+                "interface_idx": np.array(d["interface_idx_b"], dtype=np.int32),
+                "n_interface": int(d["n_interface_residues_b"]),
+                "chain_len": int(d["len_b"]),
+                "is_homodimer": bool(d["is_homodimer"]),
+            }
+        )
+    cand_long_df = pd.DataFrame(cand_long)
+    print(f"  expanded to {len(cand_long_df)} (dimer, chain-side) rows")
+
+    print("Joining + computing coverage ...")
+    merged = hits.merge(cand_long_df, left_on="query", right_on="query_key", how="inner")
+    print(f"  {len(merged)} (hit, candidate-side) rows after join")
+
+    def _coverage_row(row) -> float:
+        iface = row["interface_idx"]
+        if len(iface) == 0:
+            return 0.0
+        qs, qe = int(row["qstart"]), int(row["qend"])
+        in_range = (iface >= qs - 1) & (iface <= qe - 1)
+        return float(in_range.sum()) / float(len(iface))
+
+    merged["coverage"] = merged.apply(_coverage_row, axis=1)
+
+    keep_cols = [
+        "dimer_idx", "pdb_id", "chain_label", "partner_label", "side",
+        "query_key", "target", "source", "lddt",
+        "qstart", "qend", "qlen", "tstart", "tend", "tlen", "alnlen", "evalue",
+        "n_interface", "chain_len", "is_homodimer", "coverage",
+    ]
+    full = merged[keep_cols].copy()
+    full.to_parquet(ALL_EDGES_PATH, index=False)
+    print(f"  wrote {ALL_EDGES_PATH}  ({len(full)} rows)")
+
+    kept = full[full["coverage"] >= COVERAGE_THRESHOLD].copy()
+    kept.to_parquet(OUT_PATH, index=False)
+    print(f"  wrote {OUT_PATH}  ({len(kept)} rows above coverage {COVERAGE_THRESHOLD})")
+
+    print()
+    print("=== summary ===")
+    print(f"raw hits (both sources):     {len(hits)}")
+    print(f"hits joined to candidates:   {len(merged)}")
+    print(f"with coverage >= {COVERAGE_THRESHOLD}:        {len(kept)}")
+    if len(kept):
+        print(f"  per-source breakdown:      {kept['source'].value_counts().to_dict()}")
+        print(f"unique candidate dimers w/ >=1 kept edge: {kept['dimer_idx'].nunique()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v2/07_build_master.py
+++ b/scripts/build_ecstasy_v2/07_build_master.py
@@ -1,0 +1,293 @@
+"""Build the ecstasy_v2 master test set after applying the deleak cut.
+
+Cut rule (Pinder Level-2 defaults applied to BOTH train DBs):
+    drop dimer if EITHER chain has any Foldseek hit, against EITHER the
+    Mentos-train DB or the Boltz-2-train DB, with
+        coverage >= 0.5  AND  LDDT >= 0.7
+
+The dropped-dimer manifest tags each drop with which source(s) triggered
+it ("mentos", "boltz2", or "both") for downstream reporting.
+
+For each surviving dimer we recompute Cβ-Cβ inter-chain distance + 10-bin
+distogram exactly like v1's 07 and write <out>/data/<id[:2]>/<id>.pt.
+Manifest schema mirrors v1's so the existing benchmark loader works as-is.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import torch
+from biotite.structure import AtomArray
+from biotite.structure.io.pdb import PDBFile
+
+from ecstasy.structure import _AA3to1  # noqa: E402
+
+ROOT = Path("/projects/u6jv/ecstasy/benchmarks/ecstasy_v2")
+DIMERS_PATH = ROOT / "candidates" / "dimers.parquet"
+CHAINS_DIR = ROOT / "candidates" / "chains"
+EDGES_PATH = ROOT / "all_edges_with_coverage.parquet"
+META_PATH = ROOT / "candidates" / "rcsb_metadata.parquet"
+
+MASTER_DIR = ROOT / "master"
+DATA_DIR = MASTER_DIR / "data"
+MANIFEST_PATH = MASTER_DIR / "index.parquet"
+DROPPED_PATH = MASTER_DIR / "dropped_dimers.parquet"
+REPORT_PATH = MASTER_DIR / "master_README.md"
+
+COVERAGE_TH = 0.5
+LDDT_TH = 0.7
+
+DISTOGRAM_BINS = np.array([4, 5, 6, 7, 8, 9, 10, 11, 12], dtype=np.float32)
+
+
+@dataclass(frozen=True)
+class ChainBundle:
+    sequence: str
+    cb_xyz: np.ndarray
+    res_ids: np.ndarray
+
+
+def _virtual_cb(n: np.ndarray, ca: np.ndarray, c: np.ndarray) -> np.ndarray:
+    b = ca - n
+    c_vec = c - ca
+    a = np.cross(b, c_vec)
+    return -0.58273431 * a + 0.56802827 * b - 0.54067466 * c_vec + ca
+
+
+def load_chain_pdb(path: Path) -> ChainBundle:
+    pdb = PDBFile.read(str(path))
+    structure: AtomArray = pdb.get_structure(model=1)
+    res_ids_all, first_idx = np.unique(structure.res_id, return_index=True)
+    order = np.argsort(first_idx)
+    res_ids = res_ids_all[order].astype(np.int64)
+
+    seq_chars: list[str] = []
+    cb_coords = np.full((len(res_ids), 3), np.nan, dtype=np.float32)
+
+    for i, rid in enumerate(res_ids):
+        res_mask = structure.res_id == rid
+        res = structure[res_mask]
+        if len(res) == 0:
+            continue
+        res_name = res.res_name[0]
+        seq_chars.append(_AA3to1.get(res_name, "X"))
+        cb_mask = res.atom_name == "CB"
+        if cb_mask.any():
+            cb_coords[i] = res[cb_mask].coord[0]
+        else:
+            try:
+                n = res[res.atom_name == "N"].coord[0]
+                ca = res[res.atom_name == "CA"].coord[0]
+                c = res[res.atom_name == "C"].coord[0]
+                cb_coords[i] = _virtual_cb(n, ca, c).astype(np.float32)
+            except IndexError:
+                pass
+    return ChainBundle(
+        sequence="".join(seq_chars),
+        cb_xyz=cb_coords,
+        res_ids=res_ids,
+    )
+
+
+def compute_interchain_contact_map(
+    bundle_a: ChainBundle, bundle_b: ChainBundle
+) -> tuple[np.ndarray, np.ndarray]:
+    diff = bundle_a.cb_xyz[:, None, :] - bundle_b.cb_xyz[None, :, :]
+    dist = np.sqrt(np.sum(diff * diff, axis=-1)).astype(np.float32)
+    bad = np.isnan(dist)
+    dist[bad] = 999.0
+    contact = np.digitize(dist, DISTOGRAM_BINS, right=True).astype(np.int64)
+    contact[bad] = -1
+    return dist, contact
+
+
+def main() -> int:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    MASTER_DIR.mkdir(parents=True, exist_ok=True)
+
+    print("Loading inputs ...")
+    dimers = pd.read_parquet(DIMERS_PATH).reset_index(drop=True)
+    edges = pd.read_parquet(EDGES_PATH)
+    meta = pd.read_parquet(META_PATH)
+    print(f"  {len(dimers)} candidate dimers, {len(edges)} edges, {len(meta)} metadata rows")
+
+    # leak edges = above both thresholds
+    qual = edges[(edges["coverage"] >= COVERAGE_TH) & (edges["lddt"] >= LDDT_TH)]
+    # per-dimer source attribution
+    sources_per_dimer: dict[int, set] = {}
+    for _, e in qual.iterrows():
+        sources_per_dimer.setdefault(int(e["dimer_idx"]), set()).add(e["source"])
+    leaky_dimer_idxs = set(sources_per_dimer.keys())
+    print(
+        f"  applying cut: coverage>={COVERAGE_TH}, lddt>={LDDT_TH} -> "
+        f"{len(leaky_dimer_idxs)} dimers flagged for drop"
+    )
+    if leaky_dimer_idxs:
+        src_counts: dict[str, int] = {"mentos_only": 0, "boltz2_only": 0, "both": 0}
+        for s in sources_per_dimer.values():
+            if s == {"mentos"}:
+                src_counts["mentos_only"] += 1
+            elif s == {"boltz2"}:
+                src_counts["boltz2_only"] += 1
+            else:
+                src_counts["both"] += 1
+        print(f"  drop-source breakdown: {src_counts}")
+
+    keep_mask = ~dimers.index.isin(leaky_dimer_idxs)
+    kept = dimers[keep_mask].reset_index(drop=True)
+    dropped = dimers[~keep_mask].copy()
+    dropped["drop_sources"] = dropped.index.map(
+        lambda i: ",".join(sorted(sources_per_dimer.get(i, set()))) or None
+    )
+    dropped = dropped.reset_index(drop=True)
+    print(f"  kept: {len(kept)} | dropped: {len(dropped)}")
+
+    print("Writing GT .pt files + building manifest ...")
+    manifest_rows: list[dict] = []
+    fail_rows: list[dict] = []
+    pdb_to_meta = {r["pdb_id"]: r for _, r in meta.iterrows()}
+
+    for _, row in kept.iterrows():
+        pdb_id = row["pdb_id"]
+        assembly = row["assembly_id"]
+        chain_a = row["chain_a"]
+        chain_b = row["chain_b"]
+        entry_id = f"{pdb_id}_{chain_a}_{chain_b}"
+
+        path_a = CHAINS_DIR / f"{pdb_id}_{assembly}_{chain_a}.pdb"
+        path_b = CHAINS_DIR / f"{pdb_id}_{assembly}_{chain_b}.pdb"
+        try:
+            bundle_a = load_chain_pdb(path_a)
+            bundle_b = load_chain_pdb(path_b)
+            dist_map, contact_map = compute_interchain_contact_map(bundle_a, bundle_b)
+        except Exception as e:  # noqa: BLE001
+            fail_rows.append({"entry_id": entry_id, "error": f"{type(e).__name__}: {e}"})
+            continue
+
+        rel_path = Path("data") / entry_id[:2] / f"{entry_id}.pt"
+        out_path = MASTER_DIR / rel_path
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        torch.save(
+            {
+                "id": entry_id,
+                "pdb_id": pdb_id,
+                "chain_a": chain_a,
+                "chain_b": chain_b,
+                "sequences": [bundle_a.sequence, bundle_b.sequence],
+                "res_ids": [bundle_a.res_ids.tolist(), bundle_b.res_ids.tolist()],
+                "contact_map": torch.from_numpy(contact_map),
+                "distance_map": torch.from_numpy(dist_map),
+                "is_homodimer": bool(row["is_homodimer"]),
+            },
+            out_path,
+        )
+
+        m = pdb_to_meta.get(pdb_id)
+        manifest_rows.append(
+            {
+                "id": entry_id,
+                "pdb_id": pdb_id,
+                "chain_a": chain_a,
+                "chain_b": chain_b,
+                "len_a": int(row["len_a"]),
+                "len_b": int(row["len_b"]),
+                "total_sequence_length": int(row["len_a"] + row["len_b"]),
+                "num_chains": 2,
+                "is_homodimer": bool(row["is_homodimer"]),
+                "n_interface_residues_a": int(row["n_interface_residues_a"]),
+                "n_interface_residues_b": int(row["n_interface_residues_b"]),
+                "n_contact_pairs": int(row["n_contact_pairs"]),
+                "sequences": [bundle_a.sequence, bundle_b.sequence],
+                "relative_path": str(rel_path),
+                "deposit_date": (m["deposit_date"] if m is not None else None),
+                "release_date": (m["release_date"] if m is not None else None),
+                "resolution": (
+                    float(m["resolution"])
+                    if m is not None and m["resolution"] is not None
+                    else None
+                ),
+                "split": "test",
+            }
+        )
+
+    manifest = pd.DataFrame(manifest_rows)
+    manifest.to_parquet(MANIFEST_PATH, index=False)
+    dropped.to_parquet(DROPPED_PATH, index=False)
+    print(f"  wrote {MANIFEST_PATH}  ({len(manifest)} rows)")
+    print(f"  wrote {DROPPED_PATH}   ({len(dropped)} rows)")
+    if fail_rows:
+        pd.DataFrame(fail_rows).to_parquet(
+            MASTER_DIR / "build_failures.parquet", index=False
+        )
+        print(f"  WARNING: {len(fail_rows)} dimers failed GT generation")
+
+    md = []
+    md.append("# ecstasy_v2 master test set")
+    md.append("")
+    md.append(
+        f"Built {pd.Timestamp.now().strftime('%Y-%m-%d %H:%M:%S UTC')} "
+        "from RCSB entries released >= 2023-06-01 (Boltz-2 training cutoff)."
+    )
+    md.append("")
+    md.append("## Provenance")
+    md.append("- Source: RCSB Search API — `initial_release_date >= 2023-06-01`, X-ray, >=2 protein entities")
+    md.append("- Bio-assembly: assembly 1, all chain pairs with backbone-atom <=10 A contact")
+    md.append("- Quality filter: X-ray, resolution <=3.5 A, min chain >=40 res, total <=1200 res, >=3 contact pairs")
+    md.append("- Foldseek deleak: candidates vs **two** train DBs")
+    md.append("  - **Mentos-train**: PDB <= 2021-09-30 (Mentos seq_id_30 train split)")
+    md.append("  - **Boltz-2-train (approx)**: PDB <= 2023-06-01 — Mentos chains union all PDB chains released 2021-10-01 .. 2023-05-31 (strict superset; conservative for leakage)")
+    md.append(f"- Drop rule (either DB): coverage >= {COVERAGE_TH} AND LDDT >= {LDDT_TH}")
+    md.append("")
+    md.append("## Counts")
+    md.append(f"- Candidate dimers:                 {len(dimers)}")
+    md.append(f"- Flagged as leaky (any source):    {len(dropped)}  ({100*len(dropped)/max(1,len(dimers)):.1f}%)")
+    if leaky_dimer_idxs:
+        md.append(f"  - mentos-only:                    {src_counts['mentos_only']}")
+        md.append(f"  - boltz2-only:                    {src_counts['boltz2_only']}")
+        md.append(f"  - both:                           {src_counts['both']}")
+    md.append(f"- **Kept (master set):              {len(manifest)}**")
+    if len(manifest):
+        md.append(f"  - homodimers:                     {int(manifest['is_homodimer'].sum())}")
+        md.append(f"  - heterodimers:                   {int((~manifest['is_homodimer']).sum())}")
+        md.append(
+            f"  - total-length range:             [{manifest['total_sequence_length'].min()}, "
+            f"{manifest['total_sequence_length'].max()}]"
+        )
+        if manifest["release_date"].notna().any():
+            md.append(
+                f"  - release-date range:             {manifest['release_date'].min()} .. "
+                f"{manifest['release_date'].max()}"
+            )
+    md.append("")
+    md.append("## Layout")
+    md.append("```")
+    md.append(f"{MASTER_DIR}/")
+    md.append("  index.parquet              # manifest (one row per dimer)")
+    md.append("  dropped_dimers.parquet     # leaky dimers with `drop_sources` attribution")
+    md.append("  master_README.md           # this file")
+    md.append("  data/<id[:2]>/<id>.pt      # per-dimer GT: contact_map (10-bin Cb-Cb), distance_map, sequences")
+    md.append("```")
+    md.append("")
+    md.append("## Per-entry .pt schema (same as v1)")
+    md.append("- `id`, `pdb_id`, `chain_a`, `chain_b`")
+    md.append("- `sequences`: list of two str (chain A, chain B 1-letter seqs)")
+    md.append("- `res_ids`: list of two int lists (auth residue numbers in chain order)")
+    md.append("- `contact_map`: torch int64 (Na, Nb), MINT/Mentos 10-bin Cb-Cb scheme; `-1` = missing Cb")
+    md.append("- `distance_map`: torch float32 (Na, Nb), raw Cb-Cb distances in Angstrom")
+    md.append("- `is_homodimer`: bool")
+    md.append("")
+    md.append("## Manifest schema (index.parquet)")
+    md.append("`id, pdb_id, chain_a, chain_b, len_a, len_b, total_sequence_length, num_chains,`")
+    md.append("`is_homodimer, n_interface_residues_a, n_interface_residues_b, n_contact_pairs, sequences,`")
+    md.append("`relative_path, deposit_date, release_date, resolution, split`")
+    REPORT_PATH.write_text("\n".join(md) + "\n")
+    print(f"  wrote {REPORT_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_ecstasy_v2/README.md
+++ b/scripts/build_ecstasy_v2/README.md
@@ -1,0 +1,64 @@
+# `build_ecstasy_v2` — leakage-free dimer benchmark (post-Boltz-2 cutoff)
+
+End-to-end pipeline that builds **`ecstasy_v2`**: all post-Boltz-2-cutoff
+real PDB dimers, Foldseek-deleaked against **both** the Mentos training
+chain set and a conservative approximation of the Boltz-2 training chain
+set, at Pinder Level-2 defaults (coverage ≥ 0.5, LDDT ≥ 0.7).
+
+Compared to `ecstasy_v1` (222 dimers, deleaked vs Mentos only, sourced
+from Boltz-2's `validation_ids_v2.txt`):
+
+| Aspect | v1 | v2 |
+|---|---|---|
+| Candidate source | `validation_ids_v2.txt` (1611 IDs) | RCSB Search API: `initial_release_date ≥ 2023-06-01`, X-ray, ≥2 protein chains |
+| Train-chain DB(s) | Mentos train (≤ 2021-09-30) | **Mentos train + Boltz-2 train** (≤ 2023-06-01) |
+| Deleak rule | Either chain hits Mentos at cov ≥ 0.5 ∧ LDDT ≥ 0.7 | Either chain hits **either** DB at the same thresholds |
+| Master schema | `index.parquet` + `data/<id[:2]>/<id>.pt` | identical (drop-in for the existing benchmark loader) |
+
+All bulk data lives under `/projects/u6jv/ecstasy/benchmarks/ecstasy_v2/`.
+Only code + small configs live in this repo.
+
+## Pipeline
+
+| Step | Script | Output |
+|---|---|---|
+| 1. RCSB candidate search + metadata | `01_query_rcsb_candidates.py` | `candidates/pdb_ids.txt`, `candidates/rcsb_metadata.parquet` |
+| 2. Enumerate candidate dimers | `02_enumerate_dimers.py` | `candidates/dimers.parquet`, `candidates/chains/*.pdb` |
+| 3a. Mentos-train chains | `03a_extract_mentos_chains.py` | `train_db/mentos_train_chains/*.pdb` (symlinks v1 if available) |
+| 3b. Boltz-2 delta chains | `03b_extract_boltz2_delta_chains.py` | `train_db/boltz2_delta_chains/*.pdb` (PDB released 2021-10-01 .. 2023-05-31) |
+| 4. Foldseek easy-search (both DBs) | `04_run_foldseek.py` | `foldseek_hits_mentos.m8`, `foldseek_hits_boltz2.m8` |
+| 5. Interface-coverage edges | `05_compute_interface_edges.py` | `interface_edges.parquet`, `all_edges_with_coverage.parquet` |
+| 7. Apply cut + build master `.pt` set | `07_build_master.py` | `master/index.parquet`, `master/data/<id[:2]>/<id>.pt`, `master/master_README.md` |
+
+(Step numbers skip 06 to match v1's layout: 06 was reserved for a deleak
+report in v1; v2's per-source attribution lives in `dropped_dimers.parquet`.)
+
+## Design choices (vs the v2 issue's open questions)
+
+1. **Boltz-2 training chain list.** No public explicit list, so v2 approximates
+   it as `Mentos chains ∪ all PDB chains released 2021-10-01 .. 2023-05-31`.
+   This is a strict superset and therefore **conservative** for deleaking —
+   it will not produce false negatives (missed leaks), only false positives
+   (over-strict drops). Acceptable for a test-set construction.
+2. **Scale.** RCSB returns ~30k post-cutoff X-ray protein-multimer entries.
+   v1's ~14% candidate-hit-rate suggests ~4k candidate dimers pre-deleak;
+   after dual-DB deleak we expect a few hundred. Headline counts land in
+   `master/master_README.md`.
+3. **Foldseek strategy.** Two separate `easy-search` runs (Mentos DB and
+   Boltz-2 DB) — preserves per-source attribution in the dropped-dimer
+   manifest. The Boltz-2 DB is built by `createdb`'ing both chain
+   directories together.
+4. **Mentos rename.** v2 scripts use `mentos` in identifiers and on-disk
+   layout under `ecstasy_v2/train_db/mentos_train_chains/`. On-disk data
+   paths under `/projects/u6jv/public/MINT/...` are unchanged pending #11.
+
+## Prerequisites
+
+- aarch64-built foldseek at `tools/foldseek/bin/foldseek` (install via
+  `scripts/install/foldseek.sh`)
+- Existing ecstasy `.venv-boltz` for data wrangling
+- Mentos raw CIFs at `/projects/u6jv/public/MINT/DATA/pdb/raw/cif_unzipped/`
+  (only needed if `ecstasy_v1/train_db/mint_train_chains/` is missing —
+  otherwise step 3a reuses v1's outputs via symlink)
+- Outbound HTTPS to `data.rcsb.org`, `search.rcsb.org`, `files.rcsb.org`
+  (~50k delta CIF downloads in step 3b; cache them with care)


### PR DESCRIPTION
## Summary
- Adds `scripts/build_ecstasy_v2/`, a 7-script pipeline mirroring `build_ecstasy_v1/` that widens the candidate pool from Boltz-2's `validation_ids_v2.txt` to all RCSB X-ray protein-multimer entries released ≥ 2023-06-01.
- Deleaks against BOTH the Mentos training chain set AND a Boltz-2 training-chain approximation (Mentos ∪ all PDB chains 2021-10-01..2023-05-31 = strict superset, conservative for leakage).
- Master `.pt` schema is identical to v1 so the existing benchmark loader is a drop-in. Closes #12.

## Changes
- `01_query_rcsb_candidates.py` — RCSB Search API paginator + GraphQL metadata batch.
- `02_enumerate_dimers.py` — bio-assembly 1 + same v1 quality filters (X-ray, ≤3.5 Å, chain ≥40, ≤1200 res, ≥3 contacts).
- `03a_extract_mentos_chains.py` — symlinks v1 outputs when available, else extracts from scratch.
- `03b_extract_boltz2_delta_chains.py` — RCSB-downloads delta (2021-10-01..2023-05-31).
- `04_run_foldseek.py` — two `easy-search` runs (Mentos DB, Boltz-2 union DB) for per-source attribution.
- `05_compute_interface_edges.py` — Pinder-style interface-coverage edges, tagged with `source ∈ {mentos, boltz2}`.
- `07_build_master.py` — either-DB drop rule (cov ≥ 0.5 ∧ LDDT ≥ 0.7), per-dimer Cβ-Cβ 10-bin distogram, manifest.
- `README.md` — pipeline overview + design choices vs the v2 issue's open questions.

## Quality gates
- pre-commit: skipped — no `.pre-commit-config.yaml` in repo.
- pytest unit (`-m "not integration and not installation"`): **43 passed, 23 deselected** in 7s — clean.
- pytest full: 6 pre-existing failures (`test_boltz_venv_mint_import` + 5 `test_predict_*`) all caused by missing `/projects/u6jv/public/MINT/.../seq_id_30/index.parquet` on disk, **not introduced by this PR** — this diff only adds new files under `scripts/build_ecstasy_v2/`.
- Ran on: Isambard SLURM compute node (`nid010544`), jobs 4727544 + 4727598 via `srun`.

## Reviewer notes — correctness & logic
No blockers. The pipeline mirrors v1 faithfully and the date math is sound.

- **should-fix** `04_run_foldseek.py` — Sentinel `DB_DIR / name` (a bare path) is also the DB output prefix. If a prior run crashed mid-`createdb`, the bare file exists but companion index files (`.dbtype`, `.index`, `_h*`) may be incomplete, and the check silently skips rebuild, leading to a broken/stale search. Suggestion: check `DB_DIR / f"{name}.dbtype"` or a `.done` sentinel.
- **nit** `03b` — Date bounds are correct (Mentos ≤ 2021-09-30, delta `[2021-10-01, 2023-06-01)`, candidate `≥ 2023-06-01`). However, Mentos's training split is defined by *seq_id_30 clustering* not strictly by deposit date, so some Mentos-train entries can have `initial_release_date > 2021-09-30` (re-releases/revisions). The delta query may therefore re-download a handful of CIFs Mentos already extracted. Harmless for leakage and Foldseek dedupes by structure.
- **nit** `03b` — No protein-entity filter at the chain level; the query allows `polymer_entity_count_protein >= 1`, so mixed entries (protein+RNA/DNA) will write nucleic-acid chains (sequence mapped to "X" by `_AA3to1`) into `boltz2_delta_chains/`. Bloats the DB but does not produce false leakage drops.
- **nit** `01` and `03b` — Pagination is correct: `start += page` and break on `len(all_ids) >= total or not results`.
- **nit** `05` — Coverage math is byte-identical to v1's: `(iface >= qs-1) & (iface <= qe-1)`, where `iface` is 0-indexed and Foldseek `qstart`/`qend` are 1-indexed inclusive. Verified consistent.
- **nit** `07` — Either-DB drop rule is correct: `qual` keeps any edge above thresholds regardless of `source`, then `leaky_dimer_idxs` is the union. `keep_mask = ~dimers.index.isin(...)` works because `dimers.reset_index(drop=True)` is called and `dimer_idx` in `edges` was assigned via `dimers.iterrows()` on a freshly-read parquet in step 05.
- **nit** `03a` — Symlink reuse is gated by `if CHAINS_DIR.exists() or CHAINS_DIR.is_symlink()`. Fine.

## Reviewer notes — scale, IO, robustness, resumability
- **blocker** `02` + `03b` — Zero retry / backoff on RCSB downloads; a single transient 503 or 429 (RCSB throttles aggressively at ~1k req/min/IP, and you'll fire ~30k + ~50k downloads from process pools) raises `HTTPError`/`URLError` and that PDB is permanently logged as failed. Fix: wrap `urlopen` in a retry helper with exponential backoff honoring `Retry-After`; treat 429/5xx as retryable.
- **blocker** `02` & `03a` & `03b` — No checkpointing / resumability. If the job dies at hour 12, re-running re-downloads every CIF; the parquet outputs are written only at the very end so partial work is lost. Fix: skip IDs whose chain PDB already exists on disk (or write per-PDB JSON sidecars) and aggregate at the end; stream rows to a JSONL append log.
- **blocker** `04` — `createdb` over a single flat directory holding ~60k–100k PDBs. ext4 directory lookup degrades badly past ~50k entries in one dir, and Foldseek's globbing may blow the argv limit on some clusters. Fix: bucket chain PDBs into `chains/<pdb_id[:2]>/` subdirs and pass the parent to `createdb` (it recurses).
- **should-fix** `02` & `03b` — `ProcessPoolExecutor` with futures dict over ~30k–50k IDs holds all `dimer_rows`/`chains` in memory; futures dict + pickled results buffered can peak at 5-10 GB. Fix: bounded submission loop (cap pending at 4× nworkers) and flush to parquet shards every N completions.
- **should-fix** `03b` — `nworkers = min(64, cpu*4)` of `ProcessPoolExecutor` for I/O-bound downloads: 64 concurrent connections to RCSB *will* trip rate limits. Fix: switch to `ThreadPoolExecutor(max_workers=16)`.
- **should-fix** `04` — Per-search tmp dirs and `try/finally` cleanup; gate searches behind `if HITS_*.exists(): skip` for resumability.
- **should-fix** `04` — `sentinel = DB_DIR / name` doesn't detect half-finished `createdb`; use `(DB_DIR / f"{name}.dbtype").exists()` (written last by foldseek).
- **should-fix** `03a` — Symlink reuse silently accepts a dangling symlink. Also check `CHAINS_DIR.resolve().is_dir()` and verify the v1 manifest's chain count matches on-disk PDB count.
- **nit** `01` — Same no-retry issue on search/graphql calls; volume is low (~3 search pages, ~600 graphql batches).
- **nit** `02` — `meta_df.apply(lambda r: passes_quality(r)[0], axis=1)` over 30k rows is slow; vectorize with `(method=='X-RAY DIFFRACTION') & (resolution<=3.5)`.
- **nit** `07` — `qual.iterrows()` over potentially millions of edge rows is slow; `qual.groupby('dimer_idx')['source'].agg(set)` is two orders of magnitude faster.

**Top-3 priorities** before running end-to-end: (1) retries + backoff on every RCSB `urlopen`, (2) resumability via skip-if-exists, (3) bucket chain PDBs into 2-char subdirs.

## Test plan
- [ ] Address the 3 scale-review blockers before any production run.
- [ ] Smoke-test `01_query_rcsb_candidates.py` on a 1-day date window to verify pagination + GraphQL metadata wiring.
- [ ] Smoke-test `02` on a 5-ID slice; check `dimers.parquet` schema matches v1's.
- [ ] Verify `03a` symlink path resolves to a non-empty dir on the target host.
- [ ] Sanity-check Boltz-2 union DB after `04`: count chains in `foldseek_dbs/boltz2_train_db.lookup` ≈ mentos + delta.
- [ ] Compare a few `master/data/<id>.pt` `contact_map`/`distance_map` entries against an independent biotite computation.
- [ ] Confirm `master/dropped_dimers.parquet` `drop_sources` distribution is plausible (expect most drops from mentos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)