### PR TITLE
Benchmarking layer: FLOPs profiling, MSA pipelines, chain-swap eval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,8 @@ resources/pdb_features.json
 test.ipynb
 # local machine paths + secrets (never commit)
 .env
+
+# Run-specific SLURM wrappers hardcode cluster/job paths — keep them local, not
+# committed. Document the equivalent commands in scripts/README.md instead.
+scripts/*.sbatch
+!scripts/run_experiment.sbatch

--- a/.gitmodules
+++ b/.gitmodules
@@ -15,3 +15,6 @@
 [submodule "modules/msa_pairformer"]
 	path = modules/msa_pairformer
 	url = git@github.com:softnanolab/MSA_Pairformer.git
+[submodule "third_party/colabfold-local"]
+	path = third_party/colabfold-local
+	url = git@github.com:softnanolab/colabfold-local.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# ecstasy — agent notes
+
+Contact-prediction benchmark: inter-chain P@K vs. empirically-measured inference FLOPs
+across structure models (boltz2, esmfold, msa_pairformer, mentos). Declarative
+`datasets × models`; per-model runners under `src/ecstasy/models/_runners/`.
+
+## MSA generation — DO NOT conflate the two pipelines
+
+There are **two distinct MSA pipelines for two different models**. Same local search
+engine, different output and purpose. Getting these mixed up silently corrupts results.
+
+- **Boltz-2** → `msa: boltz_csv` → local `colabfold_search` → **paired+unpaired per-chain
+  CSVs** (reproduces `boltz --use_msa_server`; a plain `.a3m` would drop ALL pairing).
+- **MSA-Pairformer** → `msa: complex` → external **softnanolab/colabfold-local** (pinned
+  `third_party/colabfold-local`) → **stitched complex a3m**; paired-filter + chain-aware
+  select + depth-512 happen at model load, not at generation.
+- `complex_api` (ColabFold API) is a **fallback only** — it is NOT how the eval MSAs were
+  generated (despite what the code's recency might suggest).
+
+Before changing anything MSA-related, read **`src/ecstasy/msa/README.md`** (the full
+model→pipeline map, the differences table, exact `ecstasy msa …` commands, and the
+colabfold-local pin). Store keys are order-dependent (`pair_hash`).
+
+## FLOPs profiling scope (when reasoning about the numbers)
+
+Measured inference FLOPs are the **contact-map dependency subgraph only**: Boltz-2 =
+trunk + distogram (diffusion/structure module skipped); ESMFold = includes its structure
+module. True FLOPs = 2×MACs via `torch.utils.flop_counter`. See `FLOPS_BENCHMARK_PLAN.md`.

--- a/FLOPS_BENCHMARK_PLAN.md
+++ b/FLOPS_BENCHMARK_PLAN.md
@@ -1,0 +1,158 @@
+# P@K vs. inference FLOPs — benchmarking plan
+
+Replace the **params** x-axis with **empirically-measured neural inference FLOPs**, so the
+compute cost of recycles and diffusion is visible. Each decision below was resolved in a
+design review; the rationale is kept so the plan is self-justifying.
+
+---
+
+## 0. The question this plot answers
+
+> *"For each available tool, how much arithmetic does it take to produce **this contact map**,
+> and what P@K does that buy?"*
+
+Not "which architecture is most FLOP-efficient at contact prediction in principle" — the
+structure predictors are charged only for the compute their **contact output** depends on
+(see §3). x = FLOPs (log), y = P@K, on the **same proteins** for both axes.
+
+---
+
+## 1. Scope of the FLOP count — decisions
+
+| # | Decision | Choice | Why |
+|---|----------|--------|-----|
+| 1 | What's in the box | **Neural forward FLOPs only.** MSA *search* (mmseqs/colabfold, CPU DB op) excluded. | FLOPs measures arithmetic in the differentiable model; MSA search is I/O-bound and ill-defined as FLOPs. MSA *dependency* is shown as a marker style (§4), not a number. |
+| 2 | How measured | **Empirical, `torch.utils.flop_counter.FlopCounterMode`.** Not analytic `6ND`, not fvcore (trace-based, misses recycle loops), not DeepSpeed. | Dispatch-based → counts real aten ops *as executed*, so recycles, diffusion steps, and per-protein MSA depth are captured natively. Has an SDPA formula. |
+| 2b| Fused-kernel blind spot | Profile the **exact `no_kernels=true` eager path** the P@K eval already runs. | Op-counters see opaque fused kernels as 0 FLOPs. The eval path is already unfused/pure-aten → fully visible **and** faithful to the P@K run. |
+| 2c| Unit convention | **True FLOPs = 2 × MACs — and `FlopCounterMode.get_total_flops()` ALREADY returns this** (empirically verified on torch 2.9.0: a pure `Linear` gives `total = 2·m·n·k`). **Report `get_total_flops()` directly; do NOT double again** (would be a 2× overcount). Store `macs = flops/2`. | Matches AF2/ESM convention; torch's counter uses the `2·MACs` formula natively. SDPA attention is counted (decomposes to `bmm`, or via the registered flash-attention formula). |
+| 3 | Per-model = a distribution, not a scalar | **Profile per-protein on the real eval set; plot the dataset-mean FLOPs** (paired with mean-P@K). Keep per-protein spread for whiskers. | FLOPs ∝ L² (and MSA depth N) → 474 different values on `val_pinder_pair`. x and y must describe the **same population**. |
+| 7 | Structure predictors: what subgraph | **(ii) Contact-map dependency subgraph only** — count exactly the ops the contact map depends on. The boundary is **per-model**, verified in source (§3.5) — it is **not** "trunk only" for everyone. | Boltz/ESMFold read contacts from a **distogram head**, but whether the 3D-structure module is on the dependency path differs by architecture (Boltz: post-hoc decoder → off-path; ESMFold: recurrent in the recycle loop → on-path). Scope (1) literally says "work to turn sequence→contact map." |
+
+**Headline x for each model = mean over `val_pinder_pair` proteins of the contact-dependency-subgraph
+FLOPs (2×MACs), `no_kernels` eager path.** The subgraph boundary per model is §3.5.
+
+### 3.5 Per-model dependency-subgraph boundaries (VERIFIED IN SOURCE)
+
+The naïve "trunk + distogram head, exclude the structure module" is **only correct for Boltz.**
+Verified against the softnano forks:
+
+| Model | Contact source | Structure/diffusion on contact path? | Count | Exclude |
+|-------|----------------|--------------------------------------|-------|---------|
+| **Boltz-2** | `distogram_module(z)` — `boltz2.py:508`, computed from trunk `z` **before** diffusion | **No.** `structure_module.sample()` (AtomDiffusion, `boltz2.py:515-562`) runs *after* the distogram, conditions on `s,z`, never feeds back into the recycle loop (`455-506`). | input_embedder + msa_module + pairformer×recycles + distogram_module | diffusion (AtomDiffusion sampling), diffusion_conditioning, confidence, bfactor |
+| **ESMFold** | `distogram_head(structure["s_z"])` — `esmfold.py:259`, from trunk pair rep | **Yes (for num_recycles ≥ 1).** The structure module runs *inside* the recycle loop (`trunk.py:203`); its predicted positions compute `recycle_bins` (`212`) that feed the **next** iteration's pair rep (`198`) → final `s_z` → distogram. | ESM2 LM + FoldingTrunk blocks + **structure_module (×recycles)** + distogram_head | only `lddt_head`, `ptm_head` (terminal, tiny linears off-path) |
+| **MENTOS** | distogram head (single forward) | n/a (no structure module) | whole forward | — (mask_inputs=False) |
+| **MSA-Pairformer** | `predict_cb_contacts` (Cβ head, layer 15) | n/a (no structure module) | trunk through layer-15 Cβ head | the `predict_confind_contacts` layer-18 secondary head (separate call in the runner) |
+
+**Consequence:** Boltz and ESMFold are deliberately **asymmetric** — diffusion excluded for Boltz,
+structure module included for ESMFold — because that asymmetry is the *truth* of decision (ii):
+count what the contact map depends on. Boltz's decoder is post-hoc; ESMFold's is recurrent.
+
+**Boltz simplification (verified):** because the distogram is computed *before* diffusion
+(`boltz2.py:508`), running Boltz with the existing `skip_run_structure=True` knob produces an
+**identical distogram → identical P@K** with no diffusion. So the (ii) count for Boltz needs **no
+module attribution** — just profile the skip-structure forward.
+
+**No exclusion machinery needed anywhere (key robustness win).** Attribution-by-module turned out
+to be *fragile*: `FlopCounterMode` only builds attribute-qualified paths (`Boltz2.structure_module`)
+when a module is entered via `__call__`, but Boltz's diffusion runs via `structure_module.sample(...)`
+(a method) — so its FLOPs would *not* sit under the `structure_module` subtree and a name-based
+subtraction would silently miss them. We sidestep this entirely:
+
+| Model | How (ii) is achieved | Exclusion needed? |
+|-------|----------------------|-------------------|
+| Boltz | `skip_run_structure=True` → diffusion never executes; counted total = trunk-only | none |
+| ESMFold | count whole `model.infer` — SM is on-path; `lddt_head`+`ptm_head` are ~0.004 TFLOP (<0.01% of the trunk) | none (document the negligible inclusion) |
+| MENTOS | whole forward `model(batch, mask_inputs=False)` | none |
+| MSA-Pairformer | whole `predict_cb_contacts(...)` call (NOT the confind head) | none |
+
+A top-level per-module breakdown is still recorded in each sidecar for the affine-in-recycles
+sanity check (§8c) and to verify (e.g.) Boltz's `structure_module` subtree FLOPs == 0 in profile
+mode (proof that diffusion was skipped).
+
+---
+
+## 2. How the count is obtained — decisions
+
+| # | Decision | Choice |
+|---|----------|--------|
+| 4a | Instrumentation point | **In-runner `profile: true` flag.** When set, the runner wraps its real forward in `FlopCounterMode` and writes a per-prediction sidecar. No standalone profiling script (would drift from the eval path). |
+| 4b | Which proteins | **Full split** (`val_pinder_pair`, 474) for the headline; fixed **seeded 40-protein** subsample only if an MSA-model's walltime forces it (recorded in the experiment YAML, never a runtime random draw). |
+| 4c | Sidecar | Per-protein `flops.json` next to `contact.npz`: `{flops, flops_macs, L, msa_depth, recycles, module_breakdown}`. An aggregator folds the mean into `comparison.csv`. |
+| 8 | Extract the (ii) count | **Per-model, per §3.5.** Boltz: profile the **skip-structure** forward (diffusion simply does not run → no attribution needed). ESMFold/MENTOS/MSA-Pairformer: wrap the contact-producing call in `FlopCounterMode`; for ESMFold use the per-module breakdown only to subtract the two terminal heads (`lddt_head`,`ptm_head`). |
+| 8b | In-process requirement | **We may edit the softnano forks** (user-confirmed). So Boltz gets a `--profile_flops` flag added to **its own predict CLI** (sets `skip_run_structure=True`, wraps the forward in `FlopCounterMode`, dumps `flops.json` into the boltz out dir) — reusing boltz's real featurization instead of reimplementing it. The ecstasy boltz_runner keeps shelling out, now passing `--profile_flops`. MENTOS/ESMFold/MSA-Pairformer already run in-process in their runners → wrap inline. |
+| 8c | Free correctness check | Trunk FLOPs must be **affine in recycles**: `base + k·per_recycle`. Fit {0,1,3,5}; non-clean fit ⇒ wrong module attribution. Intercept (k=0 single pass) must match a hand `~2·params·L` order bound. Record the contact-dependency module-name set as an **asserted list** so a future refactor that renames modules fails loudly. |
+
+---
+
+## 3. The recycle sweep — decision 6
+
+Lines mean "compute→quality at **fixed architecture**" only if the **sole** knob changing is a
+compute knob. The current presets do **not** satisfy this (`esmfold:glinker32` vs `full` change
+the *linker*, both at `num_recycles=4` — a modeling ablation, not a compute sweep).
+
+**Add dedicated single-knob sweep presets** holding everything else fixed:
+
+- **recycles ∈ {0, 1, 3, 5}**, diffusion/sampling held at **default** (Boltz `sampling_steps=25`,
+  `diffusion_samples=1`).
+- Boltz: `recycling_steps`. ESMFold: `num_recycles` (fixed linker, e.g. 32). colabfold: `num_recycle`.
+- **MENTOS, MSA-Pairformer**: no recycle knob → **single point each** (informative: fixed-x).
+
+Each sweep value = one marker; same-model markers joined by a faint line.
+
+---
+
+## 4. Presentation — decision 5
+
+Single scatter:
+
+- **x = log₁₀(FLOPs)** (models span 2–3 orders of magnitude; linear-x smears everyone but Boltz).
+- **y = P@K** (linear), the `val_pinder_pair` `inter_P@K` headline.
+- **One marker per (model × preset)**; **same-model presets joined by a faint line** = that
+  architecture's own compute→quality curve. *This is the payoff over the params plot — params are
+  constant across recycles, FLOPs are not.*
+- **Encoding:** color = model family; **marker fill = MSA dependency** (filled = boltz2,
+  msa_pairformer; hollow = mentos, esmfold, colabfold-singleseq).
+- **Error bars:** vertical = **95% bootstrap CI of P@K** over proteins (per-protein P@K already
+  exists); horizontal = faint **per-protein FLOP IQR** whisker (exposes that MSA-models have wide
+  compute spread, MENTOS is a near-vertical line).
+- **Pareto staircase:** dashed upper-left envelope (max P@K achievable at ≤ given FLOPs) = the
+  efficiency frontier, the actual takeaway.
+- **Annotations:** recycle/step count next to each point so the line is legible.
+- **Optional faint secondary marker** per structure model: the **full as-shipped** FLOPs
+  (incl. diffusion/structure module) to make the discarded compute visible without polluting the
+  architecture comparison. Caption states the headline excludes it.
+
+**Caption must state:** FLOPs = 2×MACs, `no_kernels` eager path, MSA search excluded, structure
+predictors counted on the contact-dependency subgraph only (diffusion/structure-module FLOPs they
+*also* spend for coordinates are excluded because the contact map does not depend on them).
+
+---
+
+## 5. Implementation checklist
+
+1. **Profiler util** (`metrics/flops.py`): wrap a callable in `FlopCounterMode`, return
+   `{total_macs, total_flops=2×, module_breakdown}`. Helper to sum a given subtree name-set and
+   assert it's present.
+2. **Per-runner `profile` flag** writing `flops.json` sidecar (`flops`, `flops_macs`, `L`,
+   `msa_depth`, `recycles`, `module_breakdown`). Easy for the in-process models (mentos,
+   esmfold, msa_pairformer) first.
+3. **Boltz `--profile_flops` CLI flag** (decision 8b, edit the fork): in boltz's predict path, when
+   set, force `skip_run_structure=True` and wrap the model forward in `FlopCounterMode`, dumping
+   `flops.json` next to the distogram. Verify the skip-structure distogram matches the full-pipeline
+   `distogram_<id>.npz` bit-for-bit (so the profiled path == the P@K path). ecstasy boltz_runner
+   passes `--profile_flops` through when `profile` is set.
+4. **Per-model subgraph boundary is §3.5** (verified in source). ESMFold: subtract `lddt_head` +
+   `ptm_head` via the per-module breakdown; **structure module stays IN** (recurrent, on-path).
+   Record the excluded-module name set as an asserted list so a rename fails loudly.
+5. **Sweep presets** in `models.yaml`: `r0/r1/r3/r5` per recycle-capable model, single-knob.
+6. **Aggregator**: per-protein sidecars → dataset-mean FLOPs + IQR into `comparison.csv`.
+7. **Validation**: affine-in-recycles fit per structure model (decision 8c); FlopCount
+   non-trivial vs `6ND` lower bound (catches silent fused-kernel zero-count).
+8. **Plot script**: log-x scatter per §4 (lines, fill=MSA, bootstrap CI, FLOP IQR whisker, Pareto
+   staircase, optional as-shipped secondary marker).
+
+## 6. Order of work
+
+MENTOS (single forward, trivial) → ESMFold / MSA-Pairformer (in-process already) →
+Boltz (needs the in-process path, §5.3, the only real surgery) → aggregator → plot.
+Land MENTOS+ESMFold first to validate the sidecar/aggregator/plot end-to-end before the Boltz work.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,97 @@
+# scripts/ — benchmark sweeps & figures
+
+Helper scripts for the inter-chain P@K vs. inference-FLOPs benchmark, the chain-order
+(swap) experiment, and all the figures. The **eval/sweep work is plain `ecstasy …` CLI
+calls**; the scripts here only generate plots and aggregate results.
+
+> SLURM `*.sbatch` wrappers are **not committed** — they hardcode per-cluster/per-job
+> paths. Keep them local (they're git-ignored) and use the portable commands below.
+> A minimal, parameterized template is at the end of this file.
+
+## Environment
+
+Every script (and CLI call) needs the package on `PYTHONPATH` and the data-root env
+vars resolved by `ecstasy.config.settings`. Run with the project venv:
+
+```bash
+export PYTHONPATH=src:scripts
+export DATA_ROOT=…   MENTOS_ROOT=…   ECSTASY_ROOT=…   ENVS_ROOT=…   TOOLS_ROOT=…
+export COLABFOLD_DBS=…            # local ColabFold DBs (MSA generation)
+export LOGS_DIR=…                 # W&B run files (mentos config lookup)
+PYB="$ENVS_ROOT/.venv-boltz/bin/python"   # 3.12; has ecstasy + matplotlib
+```
+
+Paths come from `settings()` (e.g. `settings().runs_root`), never hardcoded. CMU
+Concrete figures look for the font in `$CMU_FONT_DIR` (default `~/.fonts`); they fall
+back to the default font if it's not installed.
+
+## Figures (read `runs/<split>/…`, write PNG + PDF)
+
+| Script | Example |
+|---|---|
+| `plot_pak_vs_flops.py` | `$PYB scripts/plot_pak_vs_flops.py --dataset val_seq_pair [--annotate-r0] [--exclude-models boltz2_nomsa]` |
+| `plot_flops_vs_length.py` | `$PYB scripts/plot_flops_vs_length.py --dataset val_seq_chain --model esmfold --presets r0,r1,r3,r5 [--style line]` |
+| `plot_pak_vs_interface.py` | `$PYB scripts/plot_pak_vs_interface.py --dataset val_seq_pair --xmode {contacts,percent} --cap 800` |
+| `plot_pak_vs_msadepth.py` | `$PYB scripts/plot_pak_vs_msadepth.py --depth {paired,total}` |
+| `plot_swap_flops.py` | `$PYB scripts/plot_swap_flops.py` (original vs swapped overlay) |
+| `swap_compare.py` | `$PYB scripts/swap_compare.py` (ΔP@K table + scatters, orig vs swapped) |
+
+## Eval / sweep workflows (CLI)
+
+**FLOPs recycle sweep** — one GPU run per (model, preset); `--profile` writes the
+`flops.json` sidecars, then it auto-scores P@K:
+
+```bash
+for split in val_seq_chain val_seq_pair val_pinder_chain val_pinder_pair; do
+  for preset in r0 r1 r3 r5; do
+    $PYB -m ecstasy.cli run --dataset $split --model boltz2       --preset $preset --profile
+    $PYB -m ecstasy.cli run --dataset $split --model boltz2_nomsa --preset $preset --profile
+    $PYB -m ecstasy.cli run --dataset $split --model esmfold      --preset $preset --profile
+  done
+done
+$PYB -m ecstasy.cli run --dataset $split --model mentos         --preset a5sgd6ul_latest --profile
+$PYB -m ecstasy.cli run --dataset $split --model msa_pairformer --preset full            --profile
+```
+
+(In practice each `(split, model, preset)` cell is one SLURM array task — see the
+template below.)
+
+**Chain-order (swap) experiment** — isolated under the `val_seq_pair_swapped` dataset
+(chains flipped + GT reindexed; registered in `registry/datasets.yaml`):
+
+```bash
+# 1. regenerate Boltz MSAs from scratch for the flipped order (new pair-hashes)
+$PYB -m ecstasy.cli msa --datasets val_seq_pair_swapped --kind boltz_csv --phase submit   # GPU
+$PYB -m ecstasy.cli msa --datasets val_seq_pair_swapped --kind boltz_csv --phase ingest
+
+# 2. eval the order-sensitive models across recycles
+for m in boltz2 boltz2_nomsa esmfold; do for p in r0 r1 r3 r5; do
+  $PYB -m ecstasy.cli run --dataset val_seq_pair_swapped --model $m --preset $p --profile
+done; done
+
+# 3. compare original vs swapped
+$PYB scripts/swap_compare.py          # ΔP@K table + swap_scatter_<model>.png
+$PYB scripts/plot_swap_flops.py       # P@K-vs-FLOPs overlay (A,B) vs (B,A)
+```
+
+MSA generation details (Boltz `boltz_csv` vs MSA-Pairformer `complex`/`complex_api`) are
+documented in [`../src/ecstasy/msa/README.md`](../src/ecstasy/msa/README.md) — **do not
+conflate the two pipelines.**
+
+## SLURM (local wrappers, not committed)
+
+Generate a wrapper locally; resolve paths from the submit dir, don't hardcode them:
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=ecstasy --gpus-per-node=1 --ntasks-per-node=1 --time=24:00:00
+#SBATCH --array=0-15%16
+set -uo pipefail
+WT="${SLURM_SUBMIT_DIR:?}"                 # repo root — not a hardcoded path
+export PYTHONPATH="$WT/src"
+export DATA_ROOT=…  MENTOS_ROOT=…  ECSTASY_ROOT=…  ENVS_ROOT=…  TOOLS_ROOT=…  COLABFOLD_DBS=…  LOGS_DIR=…
+PYB="$ENVS_ROOT/.venv-boltz/bin/python"
+CELLS=( "val_seq_pair boltz2 r0" "val_seq_pair boltz2 r1" … )   # one (split model preset) per index
+read -r split model preset <<< "${CELLS[$SLURM_ARRAY_TASK_ID]}"
+$PYB -m ecstasy.cli run --dataset "$split" --model "$model" --preset "$preset" --profile
+```

--- a/scripts/_plotstyle.py
+++ b/scripts/_plotstyle.py
@@ -1,0 +1,35 @@
+"""Shared matplotlib style for the benchmark figures: CMU Concrete typeface.
+
+The CMU Concrete OTFs live in ~/.fonts but aren't in matplotlib's default scan,
+so we register them explicitly and set them as the default family. Math text is
+switched to Computer Modern so equations/sub-/superscripts match the body.
+"""
+from __future__ import annotations
+
+import glob
+import os
+from pathlib import Path
+
+import matplotlib
+import matplotlib.font_manager as fm
+
+# CMU Concrete OTFs (cmunorm/cmunobx/cmunoti/cmunobi). Looked up in $CMU_FONT_DIR if
+# set, else the running user's ~/.fonts — no hardcoded home. Degrades gracefully
+# (returns False) if the font isn't installed.
+_FONT_DIR = os.environ.get("CMU_FONT_DIR", str(Path.home() / ".fonts"))
+
+
+def use_cmu_concrete() -> bool:
+    """Register CMU Concrete and make it the default font. Returns True on success."""
+    files = glob.glob(os.path.join(_FONT_DIR, "cmuno*.otf"))
+    for f in files:
+        try:
+            fm.fontManager.addfont(f)
+        except Exception:        # noqa: BLE001
+            pass
+    if not any("Concrete" in f.name for f in fm.fontManager.ttflist):
+        return False
+    matplotlib.rcParams["font.family"] = "CMU Concrete"
+    matplotlib.rcParams["mathtext.fontset"] = "cm"
+    matplotlib.rcParams["axes.unicode_minus"] = False
+    return True

--- a/scripts/plot_flops_vs_length.py
+++ b/scripts/plot_flops_vs_length.py
@@ -1,0 +1,143 @@
+"""Per-protein inference FLOPs vs. sequence length, one series per preset.
+
+Reads the ``flops.json`` sidecars (written by ``ecstasy run --profile``) under
+``$DATA_ROOT/runs/<dataset>/<model>/<preset>/predictions/<id>/`` — each records
+``L`` (the model's input length) and ``flops`` — and scatters FLOPs (y) against
+L (x), one colored series per preset. For a recycle sweep the presets share an
+identical L per protein, so the series stack into parallel compute bands that
+show both the length-scaling of the architecture and the per-recycle multiplier.
+
+Usage:
+  python scripts/plot_flops_vs_length.py --dataset val_seq_chain --model esmfold \
+      --presets r0,r1,r3,r5 [--out plot.png]
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+
+import numpy as np
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+from _plotstyle import use_cmu_concrete  # noqa: E402
+
+use_cmu_concrete()  # noqa: E402
+
+from ecstasy.config import settings  # noqa: E402
+
+
+def _series(dataset: str, model: str, preset: str) -> tuple[np.ndarray, np.ndarray]:
+    root = settings().runs_root / dataset / model / preset / "predictions"
+    Ls, Fs = [], []
+    for fp in glob.glob(str(root / "*" / "flops.json")):
+        try:
+            d = json.loads(open(fp).read())
+            Ls.append(float(d["L"]))
+            Fs.append(float(d["flops"]))
+        except (json.JSONDecodeError, KeyError, OSError):
+            continue
+    order = np.argsort(Ls)
+    return np.array(Ls)[order], np.array(Fs)[order]
+
+
+def _binned_line(L, F, edges):
+    """Per-bin (center, median, p10, p90) over shared bin edges; bins with <3 points dropped.
+    Median is robust to the MSA-depth FLOPs spread; the p10-p90 band shows that spread."""
+    idx = np.digitize(L, edges)
+    cen, med, lo, hi = [], [], [], []
+    for b in range(1, len(edges)):
+        m = idx == b
+        if m.sum() < 3:
+            continue
+        cen.append(float(L[m].mean()))
+        med.append(float(np.median(F[m])))
+        lo.append(float(np.percentile(F[m], 10)))
+        hi.append(float(np.percentile(F[m], 90)))
+    return np.array(cen), np.array(med), np.array(lo), np.array(hi)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", required=True)
+    ap.add_argument("--model", default="esmfold")
+    ap.add_argument("--presets", default="r0,r1,r3,r5",
+                    help="comma-separated preset names, low->high compute (one model)")
+    ap.add_argument("--series", default="",
+                    help="comma-separated model:preset tokens for a CROSS-MODEL plot "
+                         "(e.g. boltz2:r0,esmfold:r0,msa_pairformer:full); overrides --model/--presets")
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--xlog", action="store_true", help="log-scale the x (length) axis too")
+    ap.add_argument("--style", choices=["scatter", "line"], default="scatter",
+                    help="line = binned-median curve per series + faint p10-p90 spread band")
+    ap.add_argument("--nbins", type=int, default=22, help="number of length bins for --style line")
+    args = ap.parse_args()
+
+    # Build the (model, preset, label) list and pick a palette. Recycle sweep of one
+    # model -> ordered plasma; cross-model -> categorical tab10.
+    if args.series:
+        seq = []
+        for tok in args.series.split(","):
+            tok = tok.strip()
+            if not tok:
+                continue
+            model, _, preset = tok.partition(":")
+            seq.append((model, preset, f"{model} ({preset})"))
+        cmap = plt.get_cmap("tab10")
+        colors = [cmap(i % 10) for i in range(len(seq))]
+        legend_title, title_sub = "model (preset)", "one series per model at a fixed preset"
+    else:
+        presets = [p.strip() for p in args.presets.split(",") if p.strip()]
+        seq = [(args.model, p, p) for p in presets]
+        cmap = plt.get_cmap("plasma")
+        colors = [cmap(t) for t in np.linspace(0.08, 0.82, len(seq))]
+        legend_title, title_sub = "recycles", "one series per recycle preset (r = recycling steps)"
+
+    # Collect each series' (L, FLOPs) first so line mode can share one set of bin edges.
+    data = []
+    for (model, preset, label), c in zip(seq, colors):
+        L, F = _series(args.dataset, model, preset)
+        if not L.size:
+            print(f"  (skip {model}:{preset}: no flops.json sidecars)")
+            continue
+        data.append((label, c, L, F))
+    if not data:
+        raise SystemExit(f"no flops.json under {settings().runs_root / args.dataset}")
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+    if args.style == "line":
+        allL = np.concatenate([L for _, _, L, _ in data])
+        edges = np.linspace(allL.min(), allL.max(), args.nbins + 1)
+        for label, c, L, F in data:
+            cen, med, lo, hi = _binned_line(L, F, edges)
+            ax.fill_between(cen, lo, hi, color=c, alpha=0.15, lw=0, zorder=2)
+            ax.plot(cen, med, "-", color=c, lw=1.8, zorder=3, label=f"{label}  (n={L.size})")
+    else:
+        for label, c, L, F in data:
+            ax.scatter(L, F, s=14, color=c, alpha=0.55, edgecolors="none",
+                       label=f"{label}  (n={L.size})", zorder=3)
+    drew = len(data)
+
+    ax.set_yscale("log")
+    if args.xlog:
+        ax.set_xscale("log")
+    ax.set_xlabel("total dimer sequence length L  (chainA + chainB residues = contact-map size)")
+    ax.set_ylabel("inference FLOPs  (true = 2×MACs, contact-dependency subgraph, log)")
+    head = "models" if args.series else args.model
+    if args.style == "line":
+        title_sub += "  ·  binned-median line, p10–p90 band"
+    ax.set_title(f"{head} — inference FLOPs vs. sequence length  ({args.dataset})\n{title_sub}")
+    ax.grid(True, which="both", ls=":", alpha=0.4)
+    ax.legend(title=legend_title, fontsize=9, loc="best")
+
+    fig.tight_layout()
+    out = args.out or str(settings().runs_root / args.dataset
+                          / f"flops_vs_length_{args.model}.png")
+    fig.savefig(out, dpi=160)
+    print(f"wrote {out}  ({drew} series)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_pak_vs_flops.py
+++ b/scripts/plot_pak_vs_flops.py
@@ -1,0 +1,266 @@
+"""P@K vs. inference-FLOPs plot (the deliverable; see FLOPS_BENCHMARK_PLAN.md §4).
+
+Reads every run under ``$DATA_ROOT/runs/<dataset>/<model>/<variant>/`` that has
+both a ``result.json`` (per-protein P@K) and per-protein ``flops.json`` sidecars
+(from ``ecstasy run --profile``), and draws:
+
+  * x = log10(mean inference FLOPs), y = mean P@K
+  * one marker per (model, variant); same-model presets joined by a faint line
+    (the architecture's own compute->quality curve — the whole point of the FLOPs
+    reframing over params)
+  * color = model family; marker fill = MSA dependency (filled = uses MSA)
+  * vertical bars = 95% bootstrap CI of P@K over proteins
+  * horizontal whisker = 10-90th percentile of per-protein FLOPs
+  * dashed Pareto staircase = max P@K achievable at <= given FLOPs
+
+Usage:
+  python scripts/plot_pak_vs_flops.py --dataset val_pinder_pair [--out plot.png]
+  (run from an env with ecstasy + matplotlib, e.g. .venv-boltz)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+from _plotstyle import use_cmu_concrete  # noqa: E402
+
+use_cmu_concrete()  # noqa: E402
+
+from ecstasy.config import settings  # noqa: E402
+from ecstasy.models.registry import load_model, model_names  # noqa: E402
+
+_RNG_SEED = 0          # deterministic bootstrap
+_N_BOOT = 2000
+
+
+def _msa_dependency() -> dict[str, bool]:
+    out = {}
+    for m in model_names():
+        try:
+            out[m] = load_model(m).needs_msa
+        except Exception:        # noqa: BLE001
+            out[m] = False
+    return out
+
+
+def _bootstrap_ci(values: np.ndarray) -> tuple[float, float]:
+    if values.size < 2:
+        v = float(values.mean()) if values.size else float("nan")
+        return v, v
+    rng = np.random.default_rng(_RNG_SEED)
+    means = values[rng.integers(0, values.size, size=(_N_BOOT, values.size))].mean(axis=1)
+    return float(np.percentile(means, 2.5)), float(np.percentile(means, 97.5))
+
+
+def _collect(dataset: str, partial_cap: int = 0, exclude: set[str] | None = None) -> list[dict]:
+    root = settings().runs_root / dataset
+    # Iterate every model/variant dir that has FLOPs sidecars (not just finished runs).
+    pts = []
+    entries_by_id = None     # lazily built only if partial scoring is needed
+    dataset_obj = None
+    for pred_dir in sorted(root.glob("*/*/predictions")):
+        run_dir = pred_dir.parent
+        model, variant = run_dir.parts[-2], run_dir.parts[-1]
+        if exclude and model in exclude:
+            continue
+        flops = []
+        for fp in pred_dir.glob("*/flops.json"):
+            try:
+                flops.append(float(json.loads(fp.read_text())["flops"]))
+            except (json.JSONDecodeError, KeyError, OSError):
+                continue
+        if not flops:
+            continue
+
+        result = run_dir / "result.json"
+        partial = False
+        if result.exists():
+            per = json.loads(result.read_text()).get("per_protein", {})
+            paks = np.array([v["P@K"] for v in per.values()
+                             if isinstance(v.get("P@K"), (int, float)) and v["P@K"] == v["P@K"]])
+        elif partial_cap:
+            # No result.json yet (run still in flight): score available predictions
+            # in-memory, capped, WITHOUT writing anything (don't disturb the live job).
+            if dataset_obj is None:
+                from ecstasy.datasets import load_dataset
+                dataset_obj = load_dataset(dataset)
+                entries_by_id = {e.id: e for e in dataset_obj.entries()}
+            paks, partial = _score_partial(dataset_obj, entries_by_id, pred_dir, partial_cap), True
+        else:
+            continue
+        if not paks.size or not flops:
+            continue
+
+        flops = np.array(flops)
+        lo, hi = _bootstrap_ci(paks)
+        pts.append({
+            "model": model, "variant": variant,
+            "pak": float(paks.mean()), "pak_lo": lo, "pak_hi": hi, "n_pak": int(paks.size),
+            "partial": partial,
+            "flops": float(flops.mean()), "n_flops": len(flops),
+            "flops_p10": float(np.percentile(flops, 10)),
+            "flops_p90": float(np.percentile(flops, 90)),
+        })
+    return pts
+
+
+def _score_partial(dataset_obj, entries_by_id, pred_dir, cap: int) -> np.ndarray:
+    """Score up to ``cap`` available predictions in-memory; return P@K array."""
+    paks = []
+    for entry_dir in sorted(pred_dir.glob("*")):
+        if len(paks) >= cap:
+            break
+        cpath = entry_dir / "contact.npz"
+        entry = entries_by_id.get(entry_dir.name)
+        if entry is None or not cpath.exists():
+            continue
+        try:
+            res = dataset_obj.score(entry, cpath)
+        except Exception:        # noqa: BLE001
+            continue
+        v = res.get("P@K")
+        if isinstance(v, (int, float)) and v == v:
+            paks.append(float(v))
+    return np.array(paks)
+
+
+# Human-readable model names for the legend (MSA dependency spelled out).
+_DISPLAY_NAME = {
+    "boltz2": "Boltz2 (with MSAs)",
+    "boltz2_nomsa": "Boltz2 (no MSAs)",
+    "esmfold": "ESMFold",
+    "mentos": "MENTOS",
+    "msa_pairformer": "MSA-Pairformer",
+    "colabfold": "ColabFold",
+}
+
+
+def _display_name(model: str) -> str:
+    return _DISPLAY_NAME.get(model, model)
+
+
+# Single-forward models have no recycle knob; their one preset IS the r=0 point.
+# Relabel it "r=0 full" so it reads on the same footing as the r0 sweep points.
+_R0_FULL_MODELS = {"mentos", "msa_pairformer"}
+
+
+def _disp_variant(model: str, variant: str) -> str:
+    if model in _R0_FULL_MODELS:
+        return "r=0 full"
+    return variant
+
+
+def _is_r0_rep(model: str, variant: str) -> bool:
+    """The r=0 representative of a model: its r0 sweep point, or (for single-forward
+    models) its only preset."""
+    return variant == "r0" or model in _R0_FULL_MODELS
+
+
+def _pareto(pts: list[dict]) -> list[dict]:
+    """Upper-left frontier: lowest-FLOPs points whose P@K is not beaten by a cheaper one."""
+    best = -np.inf
+    out = []
+    for p in sorted(pts, key=lambda d: d["flops"]):
+        if p["pak"] > best:
+            out.append(p)
+            best = p["pak"]
+    return out
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", required=True)
+    ap.add_argument("--out", default=None)
+    ap.add_argument("--partial-cap", type=int, default=0,
+                    help="if >0, score up to N available predictions in-memory for runs whose "
+                         "result.json isn't written yet (PREVIEW of an in-flight sweep)")
+    ap.add_argument("--exclude-models", default="",
+                    help="comma-separated model names to omit (e.g. an in-flight series)")
+    ap.add_argument("--annotate-r0", action="store_true",
+                    help="label each model's r=0 point with its mean P@K and mean T-FLOPs")
+    args = ap.parse_args()
+
+    exclude = {m.strip() for m in args.exclude_models.split(",") if m.strip()}
+    pts = _collect(args.dataset, partial_cap=args.partial_cap, exclude=exclude)
+    if not pts:
+        raise SystemExit(f"no runs with flops.json under "
+                         f"{settings().runs_root / args.dataset} — run `ecstasy run --profile` first")
+    n_partial = sum(p.get("partial", False) for p in pts)
+
+    needs_msa = _msa_dependency()
+    models = sorted({p["model"] for p in pts})
+    cmap = plt.get_cmap("tab10")
+    color = {m: cmap(i % 10) for i, m in enumerate(models)}
+
+    fig, ax = plt.subplots(figsize=(8, 6))
+
+    for m in models:
+        mpts = sorted((p for p in pts if p["model"] == m), key=lambda d: d["flops"])
+        xs = [p["flops"] for p in mpts]
+        ys = [p["pak"] for p in mpts]
+        # connecting line across this model's presets (the compute->quality curve)
+        if len(mpts) > 1:
+            ax.plot(xs, ys, "-", color=color[m], alpha=0.35, lw=1.2, zorder=1)
+        filled = needs_msa.get(m, False)
+        for p in mpts:
+            ax.errorbar(
+                p["flops"], p["pak"],
+                yerr=[[p["pak"] - p["pak_lo"]], [p["pak_hi"] - p["pak"]]],
+                xerr=[[max(0.0, p["flops"] - p["flops_p10"])], [max(0.0, p["flops_p90"] - p["flops"])]],
+                fmt="o", color=color[m], ecolor=color[m], elinewidth=0.8, capsize=2,
+                ms=8, mfc=(color[m] if filled else "white"), mec=color[m], mew=1.5, zorder=3,
+            )
+            vlabel = _disp_variant(m, p["variant"])
+            if args.annotate_r0 and _is_r0_rep(m, p["variant"]):
+                txt = f"{vlabel}\nP@K {p['pak']:.2f} · {p['flops'] / 1e12:.1f} TFLOP"
+                ax.annotate(txt, (p["flops"], p["pak"]), textcoords="offset points",
+                            xytext=(7, 5), fontsize=6.5, color=color[m], zorder=5,
+                            bbox=dict(boxstyle="round,pad=0.18", fc="white",
+                                      ec=color[m], lw=0.6, alpha=0.9))
+            else:
+                ax.annotate(vlabel, (p["flops"], p["pak"]), textcoords="offset points",
+                            xytext=(6, 4), fontsize=7, color=color[m])
+
+    # Pareto staircase (upper-left envelope): max P@K achievable at <= given FLOPs
+    pf = _pareto(pts)
+    if len(pf) > 1:
+        ax.step([p["flops"] for p in pf], [p["pak"] for p in pf], where="post",
+                color="0.4", ls="--", lw=1.0, zorder=2)
+
+    ax.set_xscale("log")
+    ax.set_xlabel("inference FLOPs (true = 2×MACs, contact-dependency subgraph, log scale)")
+    ax.set_ylabel(f"mean inter-chain P@K  ({args.dataset})")
+    title = "Contact-prediction quality vs. inference compute"
+    if n_partial:
+        title += f"\n(PREVIEW — {n_partial} run(s) partially scored, in-flight sweep)"
+    ax.set_title(title)
+    ax.grid(True, which="both", ls=":", alpha=0.4)
+
+    # legend: model colors (human-readable) + fill semantics + error-bar meaning
+    handles = [plt.Line2D([], [], marker="o", ls="", color=color[m], mfc=color[m],
+                          label=_display_name(m)) for m in models]
+    handles += [
+        plt.Line2D([], [], marker="o", ls="", color="0.3", mfc="0.3", label="filled = uses MSA"),
+        plt.Line2D([], [], marker="o", ls="", color="0.3", mfc="white", mec="0.3", label="hollow = single-seq"),
+        plt.Line2D([], [], color="0.4", marker="|", markersize=10, mew=1.5, ls="",
+                   label="vertical bar = 95% bootstrap CI of mean P@K"),
+        plt.Line2D([], [], color="0.4", marker="_", markersize=10, mew=1.5, ls="",
+                   label="horizontal bar = 10–90th pct of per-protein FLOPs"),
+        plt.Line2D([], [], ls="--", color="0.4", label="Pareto frontier"),
+    ]
+    ax.legend(handles=handles, fontsize=7.5, loc="best")
+
+    fig.tight_layout()
+    out = args.out or str(settings().runs_root / args.dataset / "pak_vs_flops.png")
+    fig.savefig(out, dpi=160)
+    print(f"wrote {out}  ({len(pts)} runs, {len(models)} models)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_pak_vs_interface.py
+++ b/scripts/plot_pak_vs_interface.py
@@ -1,0 +1,192 @@
+"""P@K vs. interface size (per model), two x-modes.
+
+  --xmode contacts : x = K = number of true inter-chain contacts (log scale)
+  --xmode percent  : x = interface residues as a % of total residues (linear)
+
+y = per-protein inter-chain P@K. One representative preset per model. Each model
+is a **binned-mean line wrapped in a translucent 95% bootstrap-CI band** (no
+per-point scatter). Per-protein (K, %, P@K) come from each run's result.json when
+present, else are scored in-memory from available predictions (PREVIEW of an
+in-flight sweep), WITHOUT writing anything.
+
+Interface residue = a residue with >=1 true inter-chain contact (Cβ-Cβ, valid);
+% = 100 * interface_residues / (La + Lb). Both x-stats come from the ground
+truth (model-independent), cached across models.
+
+Usage:
+  python scripts/plot_pak_vs_interface.py --dataset val_seq_pair --xmode percent \
+      [--presets boltz2=r1,esmfold=r1,msa_pairformer=full] [--cap 250]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+from _plotstyle import use_cmu_concrete  # noqa: E402
+
+use_cmu_concrete()
+
+from ecstasy.config import settings  # noqa: E402
+
+_DEFAULT_PRESETS = {"boltz2": "r1", "esmfold": "r1", "msa_pairformer": "full"}
+_RNG = np.random.default_rng(0)
+_N_BOOT = 1000
+_MIN_BIN = 3                      # drop bins with fewer proteins than this
+
+
+def _gt_stats(ds, cache: dict, entry):
+    """(K, interface_pct) from the GT for one entry; cached. None if unusable."""
+    if entry.id in cache:
+        return cache[entry.id]
+    out = None
+    try:
+        gt = ds.gt_for(entry.id)
+        cmap = np.asarray(gt["contact_map"]).astype(bool)
+        valid = np.asarray(gt["valid"]).astype(bool)
+        seqs = gt["sequences"]
+        if len(seqs) == 2:
+            la, lb = len(seqs[0]), len(seqs[1])
+            L = la + lb
+            if cmap.shape == (L, L):
+                cid = np.array([0] * la + [1] * lb)
+                inter = cid[:, None] != cid[None, :]
+                ti = cmap & valid & inter                     # true inter-chain contacts
+                K = int(np.triu(ti, 1).sum())
+                iface_res = int(ti.any(axis=1).sum())
+                if K > 0:
+                    out = (K, 100.0 * iface_res / L)
+    except Exception:        # noqa: BLE001
+        out = None
+    cache[entry.id] = out
+    return out
+
+
+def _collect(ds, entries, gt_cache, run_dir: Path, xmode: str, cap: int):
+    """Return (x, pak) arrays for a run. P@K from result.json if present, else
+    scored in-memory (capped). x from the GT stats (cached)."""
+    xs, paks = [], []
+    result = run_dir / "result.json"
+    have_result = result.exists()
+    per = json.loads(result.read_text()).get("per_protein", {}) if have_result else {}
+    pred_dir = run_dir / "predictions"
+
+    ids = list(per) if have_result else [p.name for p in sorted(pred_dir.glob("*"))]
+    for pid in ids:
+        if len(paks) >= cap:
+            break
+        entry = entries.get(pid)
+        if entry is None:
+            continue
+        if have_result:
+            p = per[pid].get("P@K")
+        else:
+            cpath = pred_dir / pid / "contact.npz"
+            if not cpath.exists():
+                continue
+            try:
+                p = ds.score(entry, cpath).get("P@K")
+            except Exception:        # noqa: BLE001
+                continue
+        if not isinstance(p, (int, float)) or p != p:
+            continue
+        st = _gt_stats(ds, gt_cache, entry)
+        if st is None:
+            continue
+        xs.append(st[0] if xmode == "contacts" else st[1])
+        paks.append(float(p))
+    return np.array(xs, float), np.array(paks, float)
+
+
+def _binned(x: np.ndarray, y: np.ndarray, edges: np.ndarray):
+    """Per-bin (center, mean, ci_lo, ci_hi); bins with < _MIN_BIN points dropped."""
+    idx = np.digitize(x, edges) - 1
+    cen, mean, lo, hi = [], [], [], []
+    log = (edges[0] > 0) and (edges[-1] / max(edges[0], 1e-9) > 50)
+    for b in range(len(edges) - 1):
+        yb = y[idx == b]
+        if yb.size < _MIN_BIN:
+            continue
+        c = np.sqrt(edges[b] * edges[b + 1]) if log else 0.5 * (edges[b] + edges[b + 1])
+        boots = yb[_RNG.integers(0, yb.size, size=(_N_BOOT, yb.size))].mean(axis=1)
+        cen.append(c); mean.append(float(yb.mean()))
+        lo.append(float(np.percentile(boots, 2.5))); hi.append(float(np.percentile(boots, 97.5)))
+    return np.array(cen), np.array(mean), np.array(lo), np.array(hi)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", required=True)
+    ap.add_argument("--xmode", choices=["contacts", "percent"], default="contacts")
+    ap.add_argument("--presets", default=",".join(f"{k}={v}" for k, v in _DEFAULT_PRESETS.items()))
+    ap.add_argument("--cap", type=int, default=250)
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    presets = dict(p.split("=", 1) for p in args.presets.split(","))
+    root = settings().runs_root / args.dataset
+
+    from ecstasy.datasets import load_dataset
+    ds = load_dataset(args.dataset)
+    entries = {e.id: e for e in ds.entries()}
+    gt_cache: dict = {}
+
+    cmap = plt.get_cmap("tab10")
+    color = {m: cmap(i % 10) for i, m in enumerate(presets)}
+    fig, ax = plt.subplots(figsize=(8.5, 6))
+
+    series, allx, n_partial = [], [], 0
+    for model, preset in presets.items():
+        run_dir = root / model / preset
+        if not (run_dir / "predictions").exists():
+            continue
+        x, pak = _collect(ds, entries, gt_cache, run_dir, args.xmode, args.cap)
+        if x.size:
+            partial = not (run_dir / "result.json").exists()
+            n_partial += int(partial)
+            series.append((model, preset, x, pak, partial)); allx.append(x)
+    if not series:
+        raise SystemExit(f"no scorable runs under {root} for {presets}")
+
+    allx = np.concatenate(allx)
+    if args.xmode == "contacts":
+        edges = np.logspace(np.log10(max(1, allx.min())), np.log10(allx.max() + 1), 9)
+        ax.set_xscale("log")
+        ax.set_xlabel("interface size  K = # true inter-chain contacts  (log scale)")
+    else:
+        edges = np.linspace(0, np.ceil(allx.max() / 5) * 5, 11)
+        ax.set_xlabel("interface size  (% of residues at the inter-chain interface)")
+
+    for model, preset, x, pak, partial in series:
+        c = color[model]
+        cen, mean, lo, hi = _binned(x, pak, edges)
+        if not cen.size:
+            continue
+        ax.fill_between(cen, lo, hi, color=c, alpha=0.18, zorder=1)
+        ax.plot(cen, mean, "-o", color=c, lw=2, ms=4, zorder=3,
+                label=f"{model}/{preset} (n={x.size}{', partial' if partial else ''})")
+
+    ax.set_ylim(-0.02, 1.02)
+    ax.set_ylabel(f"per-protein inter-chain P@K  ({args.dataset})")
+    title = "Contact-prediction quality vs. interface size"
+    title += "  (% of length)" if args.xmode == "percent" else ""
+    if n_partial:
+        title += f"\n(PREVIEW — {n_partial} run(s) partially scored, in-flight sweep)"
+    ax.set_title(title)
+    ax.grid(True, which="both", ls=":", alpha=0.4)
+    ax.legend(fontsize=8, loc="upper left", bbox_to_anchor=(1.01, 1.0),
+              title="line = binned mean · band = 95% CI", frameon=False)
+
+    fig.tight_layout()
+    out = args.out or str(root / f"pak_vs_interface_{args.xmode}.png")
+    fig.savefig(out, dpi=160)
+    print(f"wrote {out}  ({len(series)} models, {allx.size} proteins, xmode={args.xmode})")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_pak_vs_msadepth.py
+++ b/scripts/plot_pak_vs_msadepth.py
@@ -1,0 +1,133 @@
+"""Mean inter-chain P@K vs. paired-MSA depth, per model.
+
+x = paired MSA depth of the complex (number of *paired* homologs in the Boltz-2
+boltz_csv MSA, key != -1 — the sequences that carry inter-chain coevolution; uncapped,
+a per-complex property). y = mean P@K, one line per model with a 95% bootstrap-CI band.
+Pools the four original val splits. MSA-using models (boltz2, msa_pairformer) should
+climb with depth; single-seq models (boltz2_nomsa, esmfold, mentos) should stay flat.
+"""
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+from _plotstyle import use_cmu_concrete  # noqa: E402
+
+use_cmu_concrete()
+
+from ecstasy.config import settings  # noqa: E402
+from ecstasy.datasets import load_dataset  # noqa: E402
+from ecstasy.msa import store  # noqa: E402
+
+R = settings().runs_root
+SPLITS = ["val_seq_chain", "val_seq_pair", "val_pinder_chain", "val_pinder_pair"]
+# model -> (preset, display, color-index)
+MODELS = [("boltz2", "r3", "Boltz2 (with MSAs)"),
+          ("msa_pairformer", "full", "MSA-Pairformer"),
+          ("esmfold", "r3", "ESMFold"),
+          ("mentos", "a5sgd6ul_latest", "MENTOS"),
+          ("boltz2_nomsa", "r3", "Boltz2 (no MSAs)")]
+_BINS = {  # well-populated bin edges per depth mode (distributions differ a lot)
+    "paired": [0, 1, 8, 128, 2048, 9000],          # paired depth 1..8192
+    "total":  [0, 512, 4096, 9000, 13000, 17000],  # total depth 2..16383
+}
+_MINBIN = 20
+
+
+def _depth(seqs, mode) -> int:
+    """MSA depth from the boltz_csv chain-0 CSV (0 if absent). mode='paired' counts only
+    paired rows (key != -1, inter-chain coevolution); 'total' counts all sequences."""
+    p = store.path_for_boltz_csv(seqs, 0)
+    if not p.exists():
+        return 0
+    n = 0
+    with open(p) as f:
+        next(f, None)  # header
+        for line in f:
+            if mode == "total" or not line.startswith("-1,"):
+                n += 1
+    return n
+
+
+def _paks(split, model, preset):
+    rj = R / split / model / preset / "result.json"
+    if not rj.exists():
+        return {}
+    per = json.loads(rj.read_text()).get("per_protein", {})
+    return {k: v["P@K"] for k, v in per.items()
+            if isinstance(v.get("P@K"), (int, float)) and v["P@K"] == v["P@K"]}
+
+
+def _ci(v):
+    if v.size < 2:
+        return float(v.mean()), float(v.mean())
+    rng = np.random.default_rng(0)
+    m = v[rng.integers(0, v.size, size=(1000, v.size))].mean(axis=1)
+    return float(np.percentile(m, 2.5)), float(np.percentile(m, 97.5))
+
+
+def main():
+    import argparse
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--depth", choices=["paired", "total"], default="paired",
+                    help="paired = inter-chain homologs (key!=-1); total = all sequences")
+    mode = ap.parse_args().depth
+    # depth per (split, id), pak per (split, id, model)
+    depth, pak = {}, {m: {} for m, _, _ in MODELS}
+    for s in SPLITS:
+        ds = load_dataset(s)
+        seqs_by_id = {e.id: e.sequences for e in ds.entries() if len(e.sequences) == 2}
+        for eid, seqs in seqs_by_id.items():
+            depth[(s, eid)] = _depth(seqs, mode)
+        for m, preset, _ in MODELS:
+            for eid, v in _paks(s, m, preset).items():
+                if eid in seqs_by_id:
+                    pak[m][(s, eid)] = v
+    keys = list(depth)
+    d_all = np.array([depth[k] for k in keys])
+    print(f"pooled complexes: {len(keys)}  paired-depth: "
+          f"min={d_all.min()} median={int(np.median(d_all))} max={d_all.max()}  "
+          f"zero-depth(single-seq fallback)={(d_all==0).sum()}")
+
+    bins = _BINS[mode]
+    cmap = plt.get_cmap("tab10")
+    fig, ax = plt.subplots(figsize=(8.5, 6))
+    centers = [np.sqrt(max(bins[i], 1) * bins[i + 1]) for i in range(len(bins) - 1)]
+    for ci_, (m, _, disp) in enumerate(MODELS):
+        xs, ys, los, his = [], [], [], []
+        for i in range(len(bins) - 1):
+            lo_e, hi_e = bins[i], bins[i + 1]
+            vals = np.array([pak[m][k] for k in keys
+                             if k in pak[m] and lo_e <= depth[k] < hi_e])
+            if vals.size < _MINBIN:
+                continue
+            lo, hi = _ci(vals)
+            xs.append(centers[i]); ys.append(vals.mean()); los.append(lo); his.append(hi)
+        if not xs:
+            continue
+        c = cmap(ci_)
+        ax.fill_between(xs, los, his, color=c, alpha=0.15, lw=0)
+        ax.plot(xs, ys, "-o", color=c, lw=1.8, ms=5, label=disp)
+
+    lab = "paired" if mode == "paired" else "total"
+    extra = "# paired homologs, key!=-1" if mode == "paired" else "# sequences, paired+unpaired"
+    ax.set_xscale("log")
+    ax.set_xlabel(f"{lab} MSA depth  ({extra} in the Boltz-2 MSA, log scale)")
+    ax.set_ylabel("mean inter-chain P@K")
+    ax.set_title(f"Inter-chain P@K vs. {lab}-MSA depth\n"
+                 "(pooled val splits; MSA models sit above single-seq baselines)")
+    ax.grid(True, which="both", ls=":", alpha=0.4)
+    ax.legend(fontsize=8, loc="best")
+    fig.tight_layout()
+    out = R / f"pak_vs_msadepth_{mode}.png"
+    fig.savefig(out, dpi=160); fig.savefig(out.with_suffix(".pdf"))
+    print(f"wrote {out} (+pdf)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/plot_swap_flops.py
+++ b/scripts/plot_swap_flops.py
@@ -1,0 +1,94 @@
+"""P@K vs. inference-FLOPs — original chain order (A,B) vs swapped (B,A), val_seq_pair.
+
+Same axes/encoding as plot_pak_vs_flops.py but overlays the two chain orders for the
+three swap-experiment models (boltz2, boltz2_nomsa, esmfold) across r0/r1/r3/r5:
+filled markers + solid line = original; open markers + dashed line = swapped. The two
+curves coincide -> the compute->quality tradeoff is order-symmetric in the mean (the
+order effect is per-protein, see the scatter figures).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+from _plotstyle import use_cmu_concrete  # noqa: E402
+from ecstasy.config import settings  # noqa: E402
+
+use_cmu_concrete()
+
+R = settings().runs_root
+MODELS = [("boltz2", "Boltz2 (with MSAs)"), ("boltz2_nomsa", "Boltz2 (no MSAs)"),
+          ("esmfold", "ESMFold")]
+PRESETS = ["r0", "r1", "r3", "r5"]
+_RNG, _NB = 0, 2000
+
+
+def _ci(v: np.ndarray):
+    if v.size < 2:
+        return float(v.mean()), float(v.mean())
+    rng = np.random.default_rng(_RNG)
+    m = v[rng.integers(0, v.size, size=(_NB, v.size))].mean(axis=1)
+    return float(np.percentile(m, 2.5)), float(np.percentile(m, 97.5))
+
+
+def _cell(split, model, preset):
+    base = R / split / model / preset
+    rj = base / "result.json"
+    if not rj.exists():
+        return None
+    per = json.loads(rj.read_text()).get("per_protein", {})
+    pak = np.array([v["P@K"] for v in per.values()
+                    if isinstance(v.get("P@K"), (int, float)) and v["P@K"] == v["P@K"]])
+    fl = np.array([json.loads(fp.read_text())["flops"]
+                   for fp in base.glob("predictions/*/flops.json")])
+    if not pak.size or not fl.size:
+        return None
+    lo, hi = _ci(pak)
+    return float(fl.mean()), float(pak.mean()), lo, hi
+
+
+def main():
+    cmap = plt.get_cmap("tab10")
+    color = {m: cmap(i) for i, (m, _) in enumerate(MODELS)}
+    fig, ax = plt.subplots(figsize=(8, 6))
+    for split, fld, ls, mk in [("val_seq_pair", True, "-", "o"),
+                               ("val_seq_pair_swapped", False, "--", "s")]:
+        for m, _ in MODELS:
+            pts = [(_cell(split, m, p)) for p in PRESETS]
+            pts = [(p, c) for p, c in zip(PRESETS, pts) if c]
+            if not pts:
+                continue
+            xs = [c[0] for _, c in pts]; ys = [c[1] for _, c in pts]
+            ax.plot(xs, ys, ls, color=color[m], alpha=0.45, lw=1.2, zorder=1)
+            for p, c in pts:
+                f, pak, lo, hi = c
+                ax.errorbar(f, pak, yerr=[[pak - lo], [hi - pak]], fmt=mk, color=color[m],
+                            ecolor=color[m], elinewidth=0.8, capsize=2, ms=7,
+                            mfc=(color[m] if fld else "white"), mec=color[m], mew=1.4, zorder=3)
+
+    ax.set_xscale("log")
+    ax.set_xlabel("inference FLOPs (true = 2×MACs, contact-dependency subgraph, log scale)")
+    ax.set_ylabel("mean inter-chain P@K  (val_seq_pair)")
+    ax.set_title("Contact-prediction quality vs. inference compute\n"
+                 "chain order (A,B) vs (B,A) — the mean curve is order-symmetric")
+    ax.grid(True, which="both", ls=":", alpha=0.4)
+    handles = [plt.Line2D([], [], marker="o", ls="", color=color[m], mfc=color[m], label=lbl)
+               for m, lbl in MODELS]
+    handles += [
+        plt.Line2D([], [], marker="o", ls="-", color="0.3", mfc="0.3", label="filled, solid = original (A,B)"),
+        plt.Line2D([], [], marker="s", ls="--", color="0.3", mfc="white", mec="0.3", label="open, dashed = swapped (B,A)"),
+        plt.Line2D([], [], color="0.4", marker="|", markersize=10, mew=1.5, ls="", label="bar = 95% bootstrap CI of mean P@K"),
+    ]
+    ax.legend(handles=handles, fontsize=7.5, loc="best")
+    fig.tight_layout()
+    out = R / "val_seq_pair_swapped" / "swap_pak_vs_flops.png"
+    fig.savefig(out, dpi=160); fig.savefig(out.with_suffix(".pdf"))
+    print(f"wrote {out} (+pdf)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/swap_compare.py
+++ b/scripts/swap_compare.py
@@ -1,0 +1,71 @@
+"""Chain-permutation experiment analysis: original val_seq_pair vs val_seq_pair_swapped.
+
+Per (model, recycle) reports mean P@K original vs swapped, the mean delta, the
+per-protein mean |delta| (order-sensitivity magnitude), Pearson r, and the fraction
+of dimers whose P@K moves by >0.05 when chains are flipped. Writes a paired-scatter
+PNG per model. mentos/msa_pairformer excluded (not part of the experiment)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt  # noqa: E402
+from ecstasy.config import settings  # noqa: E402
+
+R = settings().runs_root
+MODELS = ["boltz2", "boltz2_nomsa", "esmfold"]
+PRESETS = ["r0", "r1", "r3", "r5"]
+ORIG, SWAP = "val_seq_pair", "val_seq_pair_swapped"
+
+
+def per_protein(split: str, model: str, preset: str) -> dict[str, float]:
+    p = R / split / model / preset / "result.json"
+    if not p.exists():
+        return {}
+    per = json.loads(p.read_text()).get("per_protein", {})
+    return {k: v["P@K"] for k, v in per.items()
+            if isinstance(v.get("P@K"), (int, float)) and v["P@K"] == v["P@K"]}
+
+
+def main() -> None:
+    print(f"{'model':14}{'rec':4}{'n':>5}{'origP@K':>9}{'swapP@K':>9}{'Δmean':>8}"
+          f"{'mean|Δ|':>9}{'r':>7}{'|Δ|>.05':>9}")
+    rows = []
+    for m in MODELS:
+        fig, ax = plt.subplots(figsize=(5, 5))
+        for pi, pr in enumerate(PRESETS):
+            o = per_protein(ORIG, m, pr)
+            s = per_protein(SWAP, m, pr)
+            ids = sorted(set(o) & set(s))
+            if not ids:
+                print(f"{m:14}{pr:4}{'--  (missing results)':>40}")
+                continue
+            oa = np.array([o[i] for i in ids])
+            sa = np.array([s[i] for i in ids])
+            d = sa - oa
+            r = float(np.corrcoef(oa, sa)[0, 1]) if len(ids) > 2 else float("nan")
+            frac = float(np.mean(np.abs(d) > 0.05))
+            print(f"{m:14}{pr:4}{len(ids):>5}{oa.mean():>9.3f}{sa.mean():>9.3f}"
+                  f"{d.mean():>+8.3f}{np.abs(d).mean():>9.3f}{r:>7.3f}{frac:>9.1%}")
+            rows.append({"model": m, "recycle": pr, "n": len(ids),
+                         "orig": oa.mean(), "swap": sa.mean(), "dmean": float(d.mean()),
+                         "mad": float(np.abs(d).mean()), "r": r, "frac_gt05": frac})
+            ax.scatter(oa, sa, s=6, alpha=0.35, label=f"{pr} (|Δ|={np.abs(d).mean():.3f})")
+        ax.plot([0, 1], [0, 1], "k--", lw=0.8, alpha=0.6)
+        ax.set_xlabel("P@K original (A,B)"); ax.set_ylabel("P@K swapped (B,A)")
+        ax.set_title(f"{m} — chain-order sensitivity (val_seq_pair)")
+        ax.legend(fontsize=7, loc="best"); ax.set_aspect("equal")
+        out = R / SWAP / f"swap_scatter_{m}.png"
+        fig.tight_layout(); fig.savefig(out, dpi=150)
+        fig.savefig(out.with_suffix(".pdf"))   # vector copy for the FYP report
+        plt.close(fig)
+        print(f"  wrote {out} (+pdf)")
+    (R / SWAP / "swap_compare.json").write_text(json.dumps(rows, indent=2))
+    print(f"\nwrote {R / SWAP / 'swap_compare.json'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ecstasy/cli.py
+++ b/src/ecstasy/cli.py
@@ -45,10 +45,16 @@ class Ecstasy:
             print(f"  {m:16} msa={mr.msa:9} env={mr.env.name:14} presets={presets_for(m)}")
 
     def msa(self, datasets, kind, phase="prepare", a3m_dir=None):
-        """Populate the shared MSA store via colabfold-local.
+        """Populate the shared MSA store for a given `kind`.
 
-        phase: prepare (write missing-chains FASTA), submit (sbatch colabfold),
-               or ingest (copy resulting a3ms into the store).
+        kind: boltz_csv (Boltz-2 per-chain CSVs, local colabfold_search) |
+              complex (MSA-Pairformer stitched a3m, local colabfold-local) |
+              complex_api (MSA-Pairformer via the ColabFold API — fallback only).
+        Each model uses a DIFFERENT pipeline; see src/ecstasy/msa/README.md.
+
+        phase: prepare (write missing-complex FASTA/manifest), submit (sbatch the
+               local search; complex_api fetches inline), or ingest (assemble/copy
+               results into the store).
         """
         from ecstasy.msa import generate
         ds = _as_list(datasets)
@@ -61,11 +67,16 @@ class Ecstasy:
         else:
             raise ValueError(f"--phase must be prepare|submit|ingest, got {phase!r}")
 
-    def run(self, dataset, model, preset=None, set=None, limit=None, no_score=False):
-        """Predict (and score, unless --no_score) over the dataset×model matrix."""
+    def run(self, dataset, model, preset=None, set=None, limit=None, no_score=False,
+            profile=False):
+        """Predict (and score, unless --no_score) over the dataset×model matrix.
+
+        --profile additionally measures inference FLOPs and writes a flops.json
+        sidecar next to each contact.npz (see FLOPS_BENCHMARK_PLAN.md).
+        """
         for r in _matrix(dataset, model, preset, set):
             print(f"\n=== {r.dataset.name} × {r.model.name}/{r.model.variant} (predict) ===")
-            pipeline.run_predict(r, limit=limit)
+            pipeline.run_predict(r, limit=limit, profile=profile)
             if not no_score:
                 pipeline.run_score(r, limit=limit)
 

--- a/src/ecstasy/datasets/mentos.py
+++ b/src/ecstasy/datasets/mentos.py
@@ -21,12 +21,21 @@ class MentosSquareDataset(Dataset):
     kind = "mentos_square"
 
     def __init__(self, name: str, index: str, gt_root: str, split: str = "val",
-                 contact_bin: int = 5):
+                 contact_bin: int = 5, swap_chains: bool = False):
         super().__init__(name)
         self.index = Path(index)
         self.gt_root = Path(gt_root)
         self.split = split
         self.contact_bin = int(contact_bin)
+        # swap_chains: chain-order-permutation experiment. Reverse each dimer's chain
+        # order (A,B)->(B,A) at input AND reindex the square GT to match, so the model
+        # is scored on the same interface seen in flipped order. Monomers pass through.
+        self.swap_chains = bool(swap_chains)
+
+    @staticmethod
+    def _swap_perm(la: int, L: int) -> np.ndarray:
+        # new concat order = chainB (orig [la:L)) then chainA (orig [0:la))
+        return np.r_[np.arange(la, L), np.arange(0, la)]
 
     def entries(self) -> Iterable[Entry]:
         import pandas as pd
@@ -35,6 +44,8 @@ class MentosSquareDataset(Dataset):
         df = df[df["split"] == self.split]
         for row in df.itertuples():
             seqs = tuple(row.sequences)
+            if self.swap_chains and len(seqs) == 2:
+                seqs = (seqs[1], seqs[0])
             chain_ids = tuple(["A", "B"][: len(seqs)])
             yield Entry(id=str(row.id), sequences=seqs, chain_ids=chain_ids)
 
@@ -50,8 +61,13 @@ class MentosSquareDataset(Dataset):
         # (raw >= 0). Unresolved (-1) pairs are dropped from the candidate pool so they
         # never count as negatives (matches mentos.metrics_inter_chain).
         valid = raw >= 0
-        return {"contact_map": contact_map, "valid": valid,
-                "sequences": list(sample.sequences)}
+        seqs = list(sample.sequences)
+        if self.swap_chains and len(seqs) == 2:
+            perm = self._swap_perm(len(seqs[0]), contact_map.shape[0])
+            contact_map = contact_map[np.ix_(perm, perm)]
+            valid = valid[np.ix_(perm, perm)]
+            seqs = [seqs[1], seqs[0]]
+        return {"contact_map": contact_map, "valid": valid, "sequences": seqs}
 
     def score(self, entry: Entry, contact_path: Path) -> dict[str, float]:
         d = np.load(contact_path)

--- a/src/ecstasy/models/_runners/_boltz_profile.py
+++ b/src/ecstasy/models/_runners/_boltz_profile.py
@@ -1,0 +1,134 @@
+"""In-process Boltz-2 trunk-only FLOP profiling, without editing the boltz fork.
+
+Boltz's contact map is the trunk distogram (``boltz2.py``: ``pdistogram =
+distogram_module(z)``), computed *before* the diffusion sampler. So the
+contact-dependency-subgraph FLOP count (decision (ii), FLOPS_BENCHMARK_PLAN.md
+§3.5) is just the forward run with ``skip_run_structure=True`` — diffusion never
+executes, the distogram is identical, and ``FlopCounterMode`` over that forward
+gives the trunk-only true FLOPs with no module attribution needed.
+
+We achieve this by monkeypatching two boltz methods at runtime (so the change
+lives in ecstasy, not in the boltz fork) and then calling boltz's own
+``predict`` so all of its real featurization/data-module/trainer setup is reused:
+
+* ``Boltz2.predict_step`` → set ``skip_run_structure``, wrap the forward in
+  ``FlopCounterMode``, return ``{pdistogram, token_masks, flops}`` (no coords).
+* ``BoltzWriter.write_on_batch_end`` → dump ``distogram_<id>.npz`` +
+  ``flops_<id>.json`` per record, and skip all structure/mmcif writing.
+
+Runs inside ``.venv-boltz`` (has boltz). Imports ``_flops`` from this directory.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _flops  # noqa: E402  (sibling helper; FlopCounterMode breakdown + 2*MACs convention)
+
+
+def _install_patches():
+    import numpy as np
+    import torch
+    from torch.utils.flop_counter import FlopCounterMode
+
+    from boltz.model.models.boltz2 import Boltz2
+    from boltz.data.write.writer import BoltzWriter
+
+    # Off the contact-map dependency path (plan §3.5). `skip_run_structure` keeps the
+    # diffusion sampler (structure_module) + diffusion_conditioning from running at all,
+    # but boltz still computes the confidence/bfactor heads — they are downstream of the
+    # discarded coordinates, not of the distogram, so subtract whatever they cost.
+    OFF_PATH = ("structure_module", "diffusion_conditioning", "confidence_module", "bfactor_module")
+
+    def profiled_predict_step(self, batch, batch_idx, dataloader_idx=0):
+        # Trunk-only: structure/diffusion never runs; the distogram (computed before
+        # diffusion) is unchanged. The (ii) count = total minus any off-path head that
+        # still ran (confidence). These run via __call__, so subtree attribution is exact.
+        self.skip_run_structure = True
+        fc = FlopCounterMode(display=False)
+        with fc:
+            out = self(
+                batch,
+                recycling_steps=self.predict_args["recycling_steps"],
+                num_sampling_steps=self.predict_args["sampling_steps"],
+                diffusion_samples=self.predict_args["diffusion_samples"],
+                max_parallel_samples=self.predict_args["max_parallel_samples"],
+                run_confidence_sequentially=True,
+            )
+        total = int(fc.get_total_flops())
+        by_module = _flops._top_level_breakdown(fc.get_flop_counts())
+        off_path = int(sum(v for k, v in by_module.items()
+                           if k.split(".")[-1] in OFF_PATH))
+        flops = total - off_path
+        return {
+            "exception": False,
+            "pdistogram": out["pdistogram"],
+            "token_masks": batch["token_pad_mask"],
+            "flops": {
+                "flops": flops,                 # contact-dependency subgraph (true FLOPs)
+                "macs": flops // 2,
+                "flops_total": total,           # whole profiled forward (audit)
+                "off_path_flops": off_path,     # confidence/bfactor subtracted
+                "by_module": by_module,
+                "recycling_steps": int(self.predict_args["recycling_steps"]),
+            },
+        }
+
+    def profiled_write_on_batch_end(self, trainer, pl_module, prediction,
+                                    batch_indices, batch, batch_idx, dataloader_idx):
+        if prediction.get("exception"):
+            self.failed += 1
+            return
+        records = batch["record"]
+        for i, record in enumerate(records):
+            rdir = self.output_dir / record.id
+            rdir.mkdir(parents=True, exist_ok=True)
+            disto = prediction["pdistogram"][i].float()
+            if disto.dim() == 4:                       # (L,L,1,B) -> (L,L,B)
+                disto = disto.squeeze(-2)
+            probs = torch.softmax(disto, dim=-1)
+            n = int(prediction["token_masks"][i].cpu().bool().sum().item())
+            probs = probs[:n, :n]
+            np.savez_compressed(
+                rdir / f"distogram_{record.id}.npz",
+                probs=probs.cpu().numpy().astype(np.float16),
+                length=np.int32(probs.shape[0]),
+            )
+            (rdir / f"flops_{record.id}.json").write_text(json.dumps(prediction["flops"]))
+
+    Boltz2.predict_step = profiled_predict_step
+    BoltzWriter.write_on_batch_end = profiled_write_on_batch_end
+    # Assert the structure subtree is absent from the trunk-only count (it should
+    # never run); checked per-record downstream from by_module in the sidecar.
+
+
+def run_profiled_predict(yaml_dir: Path, raw_out_dir: Path, *, recycling_steps: int,
+                         sampling_steps: int, diffusion_samples: int, no_kernels: bool,
+                         devices: int, num_workers: int) -> None:
+    """Patch boltz for trunk-only FLOP profiling, then run its real predict.
+
+    Writes ``<raw_out_dir>/predictions/<id>/distogram_<id>.npz`` and
+    ``flops_<id>.json`` (no structure/mmcif). Mirrors the CLI args the
+    non-profile path passes to ``boltz predict``.
+    """
+    _install_patches()
+    import boltz.main as bmain
+
+    # Call boltz's own predict (click command's underlying function) so all of its
+    # preprocessing / data module / trainer wiring is reused. Non-essential options
+    # keep their signature defaults.
+    bmain.predict.callback(
+        data=str(yaml_dir),
+        out_dir=str(raw_out_dir),
+        model="boltz2",
+        devices=int(devices),
+        recycling_steps=int(recycling_steps),
+        sampling_steps=int(sampling_steps),
+        diffusion_samples=int(diffusion_samples),
+        num_workers=int(num_workers),
+        output_format="mmcif",
+        override=True,
+        no_kernels=bool(no_kernels),
+    )

--- a/src/ecstasy/models/_runners/_flops.py
+++ b/src/ecstasy/models/_runners/_flops.py
@@ -1,0 +1,80 @@
+"""Standalone FLOP-profiling helper shared by the model runners.
+
+Imported by each ``_runners/<x>.py`` via its own directory (the runners are run
+as scripts, ``python runner.py``, so they add ``Path(__file__).parent`` to
+``sys.path`` and ``import _flops``). Depends only on ``torch`` — never on
+ecstasy — so it works inside every model venv.
+
+What it measures (see FLOPS_BENCHMARK_PLAN.md):
+
+* **True FLOPs = 2 x MACs.** ``FlopCounterMode.get_total_flops()`` already returns
+  this on torch >= 2 (verified: a pure ``Linear`` reports ``2*m*n*k``). We report
+  it directly and never double again.
+* **Whole-call counting, no module attribution.** Each caller wraps exactly the
+  contact-map-producing call; the off-path structure/diffusion compute is avoided
+  upstream (Boltz ``skip_run_structure``) or negligible (ESMFold terminal heads),
+  so the counted total *is* the contact-dependency-subgraph FLOP count.
+* A small top-level **per-module breakdown** is kept for sanity checks
+  (affine-in-recycles; verifying a skipped subtree is ~0).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+import torch
+from torch.utils.flop_counter import FlopCounterMode
+
+
+def _top_level_breakdown(flop_counts: dict[str, dict[Any, int]]) -> dict[str, int]:
+    """Per-module subtree FLOPs for the root's **direct children**.
+
+    ``FlopCounterMode.get_flop_counts()`` keys are dotted module paths
+    (``Boltz2``, ``Boltz2.structure_module``, ``Boltz2.structure_module.x`` ...)
+    and already aggregate each module's whole subtree. We keep only the root's
+    direct children (one level down), which partition the total without the
+    parent/child double counting that summing every row would cause. Useful for
+    the affine-in-recycles check and to confirm a skipped subtree (e.g. Boltz
+    ``structure_module`` under ``skip_run_structure``) reports ~0 FLOPs.
+    ``Global`` is dropped (it duplicates ``get_total_flops``).
+    """
+    paths = [p for p in flop_counts if p != "Global"]
+    if not paths:
+        return {}
+    root_len = min(len(p.split(".")) for p in paths)  # the root module's depth (==1)
+    child_len = root_len + 1
+    return {
+        p: int(sum(flop_counts[p].values()))
+        for p in paths
+        if len(p.split(".")) == child_len
+    }
+
+
+def profile_call(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> tuple[Any, dict[str, Any]]:
+    """Run ``fn(*args, **kwargs)`` under ``FlopCounterMode`` and return
+    ``(result, payload)``.
+
+    ``payload`` keys:
+      ``flops``      true FLOPs (2*MACs) of the whole counted call
+      ``macs``       ``flops // 2``
+      ``by_module``  top-level per-module subtree FLOPs (audit/sanity)
+    """
+    fc = FlopCounterMode(display=False)
+    with fc:
+        result = fn(*args, **kwargs)
+    total = int(fc.get_total_flops())
+    by_module = _top_level_breakdown(fc.get_flop_counts())
+    payload = {"flops": total, "macs": total // 2, "by_module": by_module}
+    return result, payload
+
+
+def write_flops_sidecar(out_dir: str | Path, payload: dict[str, Any], **meta: Any) -> Path:
+    """Write ``<out_dir>/flops.json`` merging ``payload`` with provenance ``meta``
+    (e.g. ``L``, ``msa_depth``, ``recycles``, ``model``). Returns the path."""
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    record = {**payload, **{k: v for k, v in meta.items() if v is not None}}
+    path = out_dir / "flops.json"
+    path.write_text(json.dumps(record, indent=1))
+    return path

--- a/src/ecstasy/models/_runners/boltz2_runner.py
+++ b/src/ecstasy/models/_runners/boltz2_runner.py
@@ -59,6 +59,7 @@ def main():
     cfg = bundle.get("params") or {}        # output-affecting params (preset + overrides)
     infra = bundle.get("infra") or {}       # machine knobs (devices/num_workers/no_kernels)
     cutoff_bin: int = int(cfg.get("contact_cutoff_bin", 19))
+    profile = bool(bundle.get("profile"))
 
     out_dir.mkdir(parents=True, exist_ok=True)
     raw_dir = out_dir / "raw"
@@ -68,24 +69,44 @@ def main():
     yaml_path = yaml_dir / f"{entry_id}.yaml"
     yaml_path.write_text(_emit_yaml(entry_id, sequences, chain_ids, msa_paths))
 
-    boltz_bin = Path(sys.executable).parent / "boltz"
-    cmd = [
-        str(boltz_bin), "predict", str(yaml_dir),
-        "--out_dir", str(raw_dir),
-        "--model", "boltz2",
-        "--devices", str(infra.get("devices", 1)),
-        "--recycling_steps", str(cfg.get("recycling_steps", 3)),
-        "--sampling_steps", str(cfg.get("sampling_steps", 25)),
-        "--diffusion_samples", str(cfg.get("diffusion_samples", 1)),
-        "--num_workers", str(infra.get("num_workers", 0)),
-        "--output_format", "mmcif",
-        "--override",
-        "--dump_distogram",
-    ]
-    if infra.get("no_kernels", True):
-        cmd.append("--no_kernels")
-    print("RUN:", " ".join(cmd), flush=True)
-    subprocess.run(cmd, check=True)
+    recycling_steps = int(cfg.get("recycling_steps", 3))
+    no_kernels = bool(infra.get("no_kernels", True))
+    if profile:
+        # Trunk-only FLOP profiling: run boltz in-process with structure skipped
+        # (diffusion never runs; the distogram, computed before diffusion, is
+        # identical). Produces distogram_<id>.npz + flops_<id>.json under raw_dir.
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import _boltz_profile
+        print(f"[boltz2] PROFILE trunk-only forward (recycling_steps={recycling_steps}, "
+              f"no_kernels={no_kernels})", flush=True)
+        _boltz_profile.run_profiled_predict(
+            yaml_dir, raw_dir,
+            recycling_steps=recycling_steps,
+            sampling_steps=int(cfg.get("sampling_steps", 25)),
+            diffusion_samples=int(cfg.get("diffusion_samples", 1)),
+            no_kernels=no_kernels,
+            devices=int(infra.get("devices", 1)),
+            num_workers=int(infra.get("num_workers", 0)),
+        )
+    else:
+        boltz_bin = Path(sys.executable).parent / "boltz"
+        cmd = [
+            str(boltz_bin), "predict", str(yaml_dir),
+            "--out_dir", str(raw_dir),
+            "--model", "boltz2",
+            "--devices", str(infra.get("devices", 1)),
+            "--recycling_steps", str(recycling_steps),
+            "--sampling_steps", str(cfg.get("sampling_steps", 25)),
+            "--diffusion_samples", str(cfg.get("diffusion_samples", 1)),
+            "--num_workers", str(infra.get("num_workers", 0)),
+            "--output_format", "mmcif",
+            "--override",
+            "--dump_distogram",
+        ]
+        if no_kernels:
+            cmd.append("--no_kernels")
+        print("RUN:", " ".join(cmd), flush=True)
+        subprocess.run(cmd, check=True)
 
     distogram_paths = list(raw_dir.glob(f"**/distogram_{entry_id}.npz"))
     if not distogram_paths:
@@ -100,6 +121,32 @@ def main():
     )
     shutil.rmtree(yaml_dir, ignore_errors=True)
     print(f"WROTE {out_dir / 'contact.npz'}  shape={contact.shape}  cutoff_bin={cutoff_bin}", flush=True)
+
+    if profile:
+        flops_paths = list(raw_dir.glob(f"**/flops_{entry_id}.json"))
+        if not flops_paths:
+            raise FileNotFoundError(f"profile mode but no flops_{entry_id}.json under {raw_dir}")
+        payload = json.loads(flops_paths[0].read_text())
+        by_module = payload.get("by_module") or {}
+        # Hard sanity: the diffusion sampler must NOT run under skip_run_structure.
+        diffusion = sum(v for k, v in by_module.items()
+                        if k.split(".")[-1] in ("structure_module", "diffusion_conditioning"))
+        if diffusion:
+            raise RuntimeError(f"diffusion subtree counted {diffusion} FLOPs — skip_run_structure "
+                               "failed; the trunk-only count would be wrong")
+        # Confidence/bfactor heads still run but were subtracted in _boltz_profile (off-path).
+        if payload.get("off_path_flops"):
+            print(f"[boltz2] off-path heads subtracted: {payload['off_path_flops']:.3e} FLOPs "
+                  f"(confidence/bfactor)", flush=True)
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import _flops
+        sidecar = _flops.write_flops_sidecar(
+            out_dir,
+            {k: payload[k] for k in ("flops", "macs", "flops_total", "off_path_flops", "by_module")
+             if k in payload},
+            L=int(contact.shape[0]), msa_depth=None, recycles=recycling_steps, model="boltz2",
+        )
+        print(f"WROTE {sidecar}  flops={payload['flops']:.3e}", flush=True)
 
 
 if __name__ == "__main__":

--- a/src/ecstasy/models/_runners/esmfold_runner.py
+++ b/src/ecstasy/models/_runners/esmfold_runner.py
@@ -43,6 +43,10 @@ def main():
     residue_index_offset: int = int(cfg.get("residue_index_offset", 512))
     num_recycles = cfg.get("num_recycles")
     chunk_size = cfg.get("chunk_size")
+    profile = bool(bundle.get("profile"))
+    if profile:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import _flops
 
     import esm
 
@@ -57,13 +61,27 @@ def main():
     seq = ":".join(sequences)
     chain_linker = "G" * chain_linker_len
     print(f"[esmfold] linker={chain_linker_len}G  residue_index_offset={residue_index_offset}", flush=True)
+    flops_payload = None
     with torch.no_grad():
-        output, _ = model.infer(
-            seq,
-            num_recycles=num_recycles,
-            chain_linker=chain_linker,
-            residue_index_offset=residue_index_offset,
-        )
+        if profile:
+            # Count the whole infer: the structure module is ON the contact path
+            # (it runs inside the recycle loop and feeds the next iteration's pair
+            # rep → final distogram), so it must be included. lddt_head/ptm_head are
+            # terminal and negligible (<0.01%). See FLOPS_BENCHMARK_PLAN.md §3.5.
+            (output, _), flops_payload = _flops.profile_call(
+                model.infer,
+                seq,
+                num_recycles=num_recycles,
+                chain_linker=chain_linker,
+                residue_index_offset=residue_index_offset,
+            )
+        else:
+            output, _ = model.infer(
+                seq,
+                num_recycles=num_recycles,
+                chain_linker=chain_linker,
+                residue_index_offset=residue_index_offset,
+            )
 
     logits = output["distogram_logits"][0]                 # (L_total, L_total, 64)
     probs = torch.softmax(logits.float(), dim=-1)
@@ -86,6 +104,14 @@ def main():
     )
     print(f"[esmfold] WROTE {out_dir / 'contact.npz'}  shape={contact.shape}  cutoff_bin={cutoff_bin}",
           flush=True)
+
+    if profile and flops_payload is not None:
+        eff_recycles = int(num_recycles) if num_recycles is not None else 4  # esm default
+        sidecar = _flops.write_flops_sidecar(
+            out_dir, flops_payload,
+            L=int(contact.shape[0]), msa_depth=0, recycles=eff_recycles, model="esmfold",
+        )
+        print(f"[esmfold] WROTE {sidecar}  flops={flops_payload['flops']:.3e}", flush=True)
 
 
 if __name__ == "__main__":

--- a/src/ecstasy/models/_runners/mentos_runner.py
+++ b/src/ecstasy/models/_runners/mentos_runner.py
@@ -1,36 +1,58 @@
 """Self-contained MENTOS runner — invoked via env's python from the outer adapter.
 
 Reads a JSON bundle from stdin:
-  { entry_id, sequences[], chain_ids[], msa_paths{} (ignored), out_dir, config }
+  { entry_id, sequences[], chain_ids[], msa_paths{} (ignored), out_dir, params{},
+    infra{}, profile(bool) }
 
-Bundle's "params" must contain:
-  model_config_path  — path to a MENTOS (Hydra/OmegaConf) YAML config used to
-                       instantiate the ContactPrediction LightningModule.
-  model_weights_path — path to a Lightning .ckpt (or .pt) of trained weights.
+Bundle's "params":
+  model_config_path   — path to a MENTOS training config YAML. May be a flat Hydra
+                        config (top-level ``model``/``data``/...) OR a W&B-wrapped
+                        ``{key: {value: ...}}`` config.yaml. Both are handled.
+  model_weights_path  — path to a Lightning ``.ckpt`` of trained weights.
+  run_id (optional)   — if set and no usable ``model_config_path``, the config is
+                        fetched from ``$LOGS_DIR`` W&B run files via the eval helper.
+  contact_cutoff_bin (optional, ignored by default) — see note below.
 
 Writes:
-  <out_dir>/contact.npz   — probs (L, L) float16, length int32
-  <out_dir>/raw/raw_inter_logits_<id>.npz (optional debug)
+  <out_dir>/contact.npz   — probs (L, L) float16 inter-chain contact probability over
+                            residues (<cls>/<eos> stripped), length int32
+  <out_dir>/flops.json    — (only when profile=True) inference-FLOPs sidecar
 
-MENTOS is single-sequence (no MSA needed), takes per-chain residues, encodes
-each chain as ``<cls>{seq}<eos>``, concatenates into a single token sequence
-with chain_ids per token, and runs the dual distogram head. Inter-chain
-logits are softmaxed and the bins below ``contact_threshold_bin`` (default 5,
-< 8 Å Cβ-Cβ) are summed to give the (L, L) contact probability over residues
-(``<cls>``/``<eos>`` positions are dropped before saving).
+Design (mirrors ``scripts/evals/evaluate_from_wandb.py`` — the current eval ref):
+  * The CURRENT MENTOS API lives in ``scripts/pretrain/pretrain_mentos.py`` (class
+    ``MENTOS``). The old ``scripts.finetune.contact_prediction.ContactPrediction``
+    no longer exists. We instantiate ``MENTOS(cfg)`` and load the checkpoint with
+    ``strict=False`` (eval.load_model).
+  * Tokenization mirrors ``mentos.data.collate_fn.CollateFn`` exactly: each chain is
+    encoded as ``<cls>{seq.replace('J','L')}<eos>`` with the ESM-1b alphabet, chains
+    are concatenated into one token sequence, and ``chain_ids`` carries the chain
+    index per token (specials inherit their chain's index — CollateFn does the same).
+  * Inference uses ``model(batch, mask_inputs=False)`` — the forward DEFAULTS to
+    masking 15% of residues (MLM), which would deflate contacts; ``mask_inputs=False``
+    feeds the unmasked tokens.
+  * Contacts come from ``distogram_to_contacts(out.predicted_distogram)`` (64-bin
+    aware, default 8 Å threshold). We do NOT hardcode a bin range or a softmax — the
+    metric owns the threshold. ``contact_cutoff_bin`` in params is accepted but
+    intentionally ignored so the runner stays faithful to the eval's contact head.
 """
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
-from types import SimpleNamespace
 
 import numpy as np
 import torch
 
 
 def _tokenize_chains(sequences, alphabet):
+    """Mirror ``CollateFn._encode_chains`` / ``_build_chain_ids`` exactly.
+
+    Each chain -> ``<cls>{seq.replace('J','L')}<eos>``; concatenate; chain_ids is
+    the chain index per token (specials inherit the chain's index). Returns
+    ``(tokens (1,T) long, chain_ids (1,T) long, chain_lengths list[int])``.
+    """
     chain_token_ids = []
     chain_lengths = []
     for s in sequences:
@@ -40,19 +62,55 @@ def _tokenize_chains(sequences, alphabet):
         chain_lengths.append(int(t.numel()))
     tokens = torch.cat(chain_token_ids, dim=0).unsqueeze(0)
     chain_ids = torch.cat(
-        [torch.full((L,), i, dtype=torch.int64) for i, L in enumerate(chain_lengths)]
+        [torch.full((length,), i, dtype=torch.int64) for i, length in enumerate(chain_lengths)]
     ).unsqueeze(0)
     return tokens, chain_ids, chain_lengths
 
 
 def _residue_token_indices(chain_lengths):
-    """Token positions corresponding to actual residues (strip <cls>/<eos>)."""
+    """Token positions of actual residues (strip the per-chain <cls>/<eos>).
+
+    For chain c spanning tokens ``[pos, pos+L)``, residues occupy ``[pos+1, pos+L-1)``.
+    Mirrors CollateFn's residue mask (``start=pos+1, end=pos+L-1``).
+    """
     idx = []
     pos = 0
-    for L in chain_lengths:
-        idx.extend(range(pos + 1, pos + L - 1))
-        pos += L
+    for length in chain_lengths:
+        idx.extend(range(pos + 1, pos + length - 1))
+        pos += length
     return torch.tensor(idx, dtype=torch.long)
+
+
+def _load_cfg(model_config_path, run_id):
+    """Return a flat Hydra DictConfig for ``MENTOS(cfg)``.
+
+    Handles three shapes via the eval's own helpers:
+      1. flat Hydra config (top-level ``model``/``data``/...) -> used as-is
+      2. W&B-wrapped ``{key: {value: ...}}`` config.yaml -> reconstruct_config
+      3. no config path but a run_id -> fetch_wandb_config($LOGS_DIR, run_id) then
+         reconstruct_config
+    """
+    from omegaconf import DictConfig, OmegaConf
+
+    from scripts.evals.evaluate_from_wandb import fetch_wandb_config, reconstruct_config
+
+    if model_config_path:
+        raw = OmegaConf.load(model_config_path)
+        if not isinstance(raw, DictConfig):
+            raise TypeError(f"expected DictConfig from {model_config_path}, got {type(raw)}")
+        # W&B config.yaml wraps every top-level key as {key: {value: ...}}. Detect
+        # by checking whether the top-level entries are all {value: ...} dicts.
+        keys = [str(k) for k in raw if not str(k).startswith("_")]
+        is_wandb_wrapped = bool(keys) and all(
+            isinstance(raw[k], DictConfig) and "value" in raw[k] for k in keys
+        )
+        return reconstruct_config(raw) if is_wandb_wrapped else raw
+
+    if run_id:
+        logs_dir = Path(os.environ["LOGS_DIR"])
+        return reconstruct_config(fetch_wandb_config(logs_dir, run_id))
+
+    raise ValueError("mentos preset must set model_config_path or run_id")
 
 
 def main():
@@ -61,52 +119,77 @@ def main():
     sequences: list[str] = bundle["sequences"]
     out_dir = Path(bundle["out_dir"])
     out_dir.mkdir(parents=True, exist_ok=True)
-    cfg = bundle.get("params") or {}
+    cfg_params = bundle.get("params") or {}
+    profile = bool(bundle.get("profile"))
 
-    model_config_path = cfg.get("model_config_path")
-    model_weights_path = cfg.get("model_weights_path")
-    if not model_config_path or not model_weights_path:
-        raise ValueError(
-            "mentos preset must set model_config_path and model_weights_path"
-        )
-    cutoff_bin: int = int(cfg.get("contact_cutoff_bin", 5))
+    model_config_path = cfg_params.get("model_config_path")
+    model_weights_path = cfg_params.get("model_weights_path")
+    run_id = cfg_params.get("run_id")
+    if not model_weights_path:
+        raise ValueError("mentos preset must set model_weights_path")
 
-    from omegaconf import OmegaConf
     import mentos
     from mentos.data.esm import Alphabet
+    from mentos.metrics.contact_prediction import distogram_to_contacts
 
-    # `scripts.finetune.contact_prediction` is co-located with the mentos repo but
-    # not a Python package (the repo intends scripts to be run as `python -m`
-    # from its root). Inject the repo root onto sys.path so `import scripts.…`
-    # resolves regardless of cwd.
+    # The mentos `scripts.*` tree is co-located with the repo but not part of the
+    # installed `mentos` package. Inject the repo root onto sys.path so
+    # `import scripts.…` (eval helpers, MENTOS class) resolves regardless of cwd.
+    # mentos.__path__[0] == <repo>/src/mentos  ->  .parent.parent == <repo>.
     mentos_repo = Path(mentos.__path__[0]).parent.parent
     if str(mentos_repo) not in sys.path:
         sys.path.insert(0, str(mentos_repo))
-    from scripts.finetune.contact_prediction import ContactPrediction
 
-    mentos_cfg = OmegaConf.load(model_config_path)
+    from scripts.evals.evaluate_from_wandb import load_model
+
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    print(f"[mentos] device={device}  cfg={model_config_path}  weights={model_weights_path}", flush=True)
+    print(
+        f"[mentos] device={device}  cfg={model_config_path}  run_id={run_id}  "
+        f"weights={model_weights_path}",
+        flush=True,
+    )
 
-    model = ContactPrediction(mentos_cfg)
-    ckpt = torch.load(model_weights_path, map_location=device, weights_only=False)
-    missing, unexpected = model.load_state_dict(ckpt["state_dict"], strict=False)
-    if missing:
-        print(f"[mentos] {len(missing)} missing keys (first 3): {missing[:3]}", flush=True)
-    if unexpected:
-        print(f"[mentos] {len(unexpected)} unexpected keys (first 3): {unexpected[:3]}", flush=True)
-    model.to(device)
-    model.eval()
+    cfg = _load_cfg(model_config_path, run_id)
+    # Reuse the eval's loader verbatim: instantiates MENTOS(cfg), sets mlm mask_prob 0
+    # and loss.mlm 0, loads state_dict(strict=False), .to(device), .eval().
+    model = load_model(cfg, Path(model_weights_path), str(device))
 
     alphabet = Alphabet.from_architecture("ESM-1b")
     tokens, chain_ids_t, chain_lengths = _tokenize_chains(sequences, alphabet)
     tokens, chain_ids_t = tokens.to(device), chain_ids_t.to(device)
-    batch = SimpleNamespace(tokens=tokens, chain_ids=chain_ids_t)
+    T = int(tokens.shape[1])
 
+    # Construct a valid ContactPredictionBatch. The forward (mask_inputs=False) reads
+    # ONLY `tokens` and `chain_ids`; every other field is consumed by loss/metrics,
+    # not the prediction path. We still fill all required fields with correctly
+    # shaped/typed dummies so the dataclass is valid and `to(device)`-able.
+    from mentos.dataclasses import ContactPredictionBatch
+
+    batch = ContactPredictionBatch(
+        ids=[entry_id],
+        tokens=tokens,  # (1, T) int64
+        chain_ids=chain_ids_t,  # (1, T) int64, chain index per token
+        true_contacts=torch.full((1, T, T), -1, dtype=torch.int64, device=device),
+        seq_lengths=torch.tensor([T], dtype=torch.int64, device=device),
+        is_homodimer=torch.zeros(1, dtype=torch.bool, device=device),
+        residue_map=torch.full((1, T), -1, dtype=torch.long, device=device),
+        distance_map=None,
+    )
+
+    flops_payload = None
     with torch.no_grad():
-        intra_logits, inter_logits = model.forward(batch)
-    probs = torch.softmax(inter_logits[0].float(), dim=-1)         # (T, T, num_bins)
-    contact_full = probs[..., :cutoff_bin].sum(-1).cpu()            # (T, T)
+        if profile:
+            sys.path.insert(0, str(Path(__file__).resolve().parent))
+            import _flops
+
+            # MENTOS is a single forward; the WHOLE forward is the contact-dependency
+            # subgraph (no structure module to exclude). Count everything.
+            out, flops_payload = _flops.profile_call(model, batch, mask_inputs=False)
+        else:
+            out = model(batch, mask_inputs=False)
+
+    # distogram_to_contacts: 64-bin aware, default 8 Å threshold; returns (B, T, T).
+    contact_full = distogram_to_contacts(out.predicted_distogram)[0].float().cpu()  # (T, T)
 
     keep = _residue_token_indices(chain_lengths)
     contact = contact_full[keep][:, keep].numpy().astype(np.float16)
@@ -115,8 +198,24 @@ def main():
         probs=contact,
         length=np.int32(contact.shape[0]),
     )
-    print(f"[mentos] WROTE {out_dir / 'contact.npz'}  shape={contact.shape}  cutoff_bin={cutoff_bin}",
-          flush=True)
+    print(
+        f"[mentos] WROTE {out_dir / 'contact.npz'}  shape={contact.shape}",
+        flush=True,
+    )
+
+    if profile and flops_payload is not None:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import _flops
+
+        sidecar = _flops.write_flops_sidecar(
+            out_dir,
+            flops_payload,
+            L=int(contact.shape[0]),
+            msa_depth=0,
+            recycles=None,
+            model="mentos",
+        )
+        print(f"[mentos] WROTE {sidecar}  flops={flops_payload['flops']:.3e}", flush=True)
 
 
 if __name__ == "__main__":

--- a/src/ecstasy/models/_runners/msa_pairformer_runner.py
+++ b/src/ecstasy/models/_runners/msa_pairformer_runner.py
@@ -85,6 +85,10 @@ def main():
     max_msa_depth: int = int(cfg.get("max_msa_depth", 512))
     weights_dir = cfg.get("weights_dir")
     hhfilter_bin = cfg.get("hhfilter_bin")
+    profile = bool(bundle.get("profile"))
+    if profile:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import _flops
     # complex paired a3m: the pipeline resolves it from the shared MSA store and
     # passes the path directly; fall back to a config dir, then single-sequence.
     complex_a3m = bundle.get("complex_a3m") or cfg.get("complex_a3m")
@@ -181,9 +185,16 @@ def main():
         complex_chain_break_indices=[chain_breaks] if chain_breaks else None,
         return_seq_weights=True,
     )
+    flops_payload = None
     with torch.no_grad(), autocast_ctx:
         # Cb-Cb head (layer 15) — the definition-matched, scored map (vs MENTOS Cb<8A GT).
-        res = model.predict_cb_contacts(**mk)
+        # Profile ONLY this call: it is the scored map's whole dependency graph (trunk
+        # through the layer-15 Cβ head). The confind head below is a separate secondary
+        # column and is deliberately excluded from the FLOP count.
+        if profile:
+            res, flops_payload = _flops.profile_call(model.predict_cb_contacts, **mk)
+        else:
+            res = model.predict_cb_contacts(**mk)
         # ConFind head (layer 18) — free secondary column (side-chain-contact definition).
         confind = None
         if hasattr(model, "predict_confind_contacts"):
@@ -203,6 +214,15 @@ def main():
         **extra,
     )
     print(f"[msa_pairformer] WROTE {out_dir / 'contact.npz'}", flush=True)
+
+    if profile and flops_payload is not None:
+        sidecar = _flops.write_flops_sidecar(
+            out_dir, flops_payload,
+            L=int(contact.shape[0]), msa_depth=int(n_seqs), recycles=None,
+            model="msa_pairformer",
+        )
+        print(f"[msa_pairformer] WROTE {sidecar}  flops={flops_payload['flops']:.3e}  "
+              f"msa_depth={n_seqs}", flush=True)
 
 
 if __name__ == "__main__":

--- a/src/ecstasy/models/adapter.py
+++ b/src/ecstasy/models/adapter.py
@@ -16,9 +16,16 @@ from ecstasy.datasets.base import Entry
 from ecstasy.models.registry import ModelRun
 
 
-def predict_one(model: ModelRun, entry: Entry, msa, out_dir: Path) -> Path:
+def predict_one(model: ModelRun, entry: Entry, msa, out_dir: Path,
+                profile: bool = False) -> Path:
     """Run `model` on `entry`. `msa` is a {chain_id: a3m} dict (per_chain),
-    a single a3m path (complex), or None."""
+    a single a3m path (complex), or None.
+
+    `profile=True` asks the runner to additionally measure inference FLOPs and
+    write a `flops.json` sidecar next to `contact.npz` (see FLOPS_BENCHMARK_PLAN.md).
+    It is a measurement mode, not an output-affecting param, so it is passed as a
+    top-level bundle field — never folded into the variant id.
+    """
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     bundle = {
@@ -30,6 +37,7 @@ def predict_one(model: ModelRun, entry: Entry, msa, out_dir: Path) -> Path:
         "out_dir": str(out_dir),
         "params": model.params,
         "infra": model.infra,
+        "profile": bool(profile),
     }
     python = model.env / "bin" / "python"
     if not python.exists():

--- a/src/ecstasy/msa/README.md
+++ b/src/ecstasy/msa/README.md
@@ -1,0 +1,73 @@
+# MSA generation in ecstasy
+
+**Read this before touching MSAs.** There are two distinct MSA pipelines for two
+different models. They use the *same* local search engine but produce *different*
+outputs for *different* purposes — conflating them silently corrupts results.
+
+## Model → pipeline map
+
+| Model (`models.yaml`) | `msa:` kind | What it gets |
+|---|---|---|
+| `boltz2` | `boltz_csv` | Boltz-2 paired+unpaired **per-chain CSVs** |
+| `msa_pairformer` | `complex` | MSA-Pairformer **stitched complex a3m** |
+| `boltz2_nomsa`, `esmfold`, `mentos` | `none` | single-sequence (no MSA) |
+| `colabfold` | `none` | colabfold_batch fetches its own |
+
+Both `boltz_csv` and `complex` are **local** (GPU `mmseqs2` against `COLABFOLD_DBS`).
+`complex_api` is a network fallback (api.colabfold.com) and was **NOT** used for the
+benchmark data — don't assume it was.
+
+## Boltz-2 (`boltz_csv`) vs MSA-Pairformer (`complex`) — the differences
+
+| | `boltz_csv` (Boltz-2) | `complex` (MSA-Pairformer) |
+|---|---|---|
+| Generator | in-repo `backends/boltz_csv.py` (sbatch) | external **softnanolab/colabfold-local** via `backends/complex.py` |
+| Engine / DBs | local `colabfold_search` (mmseqs-gpu) / `COLABFOLD_DBS` | *same engine + DBs* |
+| Pairing | `--pair-mode unpaired_paired`, taxonomy/greedy; keeps **paired + unpaired** | drops unpaired via **paired-sequence filter** (both chains <50% gaps) |
+| Selection / depth | none — **full depth** (server-like) | **chain-aware** diversity select + cap **512** |
+| Output | **per-chain CSVs** (paired/unpaired columns), Boltz format | **single complex a3m**, `#L1,L2⇥1,1` header |
+| Where filtering happens | at assembly (`msa/boltz_csv.py`) | at **model load** (`msa_pairformer_runner.py`), not at generation |
+| Goal | reproduce `boltz --use_msa_server` exactly | maximize inter-chain coevolution signal |
+| Failure if conflated | custom a3m → `taxonomy=None` → **0 pairing** (breaks Boltz) | naive concat → hhfilter keeps one-chain-diverse rows (weak inter-chain signal) |
+
+Store keys are **order-dependent** (`store.pair_hash = sha256("seqA\|seqB")`), so a
+chain-swap experiment needs MSAs regenerated for the flipped order — not reused.
+
+## How to (re)generate
+
+All via `ecstasy msa --datasets <D[,D]> --kind <kind> --phase <prepare|submit|ingest>`.
+
+```bash
+# Boltz-2 MSAs (per-chain CSVs)
+ecstasy msa --datasets val_seq_chain --kind boltz_csv --phase submit   # sbatch GPU search
+ecstasy msa --datasets val_seq_chain --kind boltz_csv --phase ingest   # assemble CSVs into store
+
+# MSA-Pairformer MSAs (local colabfold-local; how the eval data was made)
+ecstasy msa --datasets val_seq_chain --kind complex --phase submit     # sbatch colabfold-local
+# (writes straight to the store; `--phase ingest` then just verifies coverage)
+
+# Manual colabfold-local run already done elsewhere? ingest its a3ms (named <pair_hash>.a3m):
+ecstasy msa --datasets val_seq_chain --kind complex --phase ingest --a3m_dir <dir>
+
+# Network fallback only (NOT the eval path):
+ecstasy msa --datasets val_seq_chain --kind complex_api --phase submit
+```
+
+Store layout: `$DATA_ROOT/msa_store/{boltz_csv,complex,...}/` keyed by hash.
+
+## colabfold-local dependency (the `complex` route)
+
+- Repo: `git@github.com:softnanolab/colabfold-local.git`
+- **Pinned commit: `38088c9`** ("chain-aware MSA selection + paired filtering for complexes")
+- Vendored as the git submodule `third_party/colabfold-local`. Override with
+  `COLABFOLD_LOCAL_DIR` (checkout) and `COLABFOLD_LOCAL_VENV` (its venv) if installed
+  elsewhere (e.g. `~/colabfold-local`).
+- The submit job exports `DATA_DIR=$COLABFOLD_DBS` and `MMSEQS_BIN` (ecstasy's
+  mmseqs-gpu) so the engine/DBs match `boltz_csv`. colabfold-local's
+  `get_paired_msa_local()` is the exact function the eval used.
+
+## Gotcha (learned the hard way)
+
+The in-repo `complex_api.py` (API) postdates the actual data (added 2026-05-30; the
+a3ms were written 2026-05-29). The eval MSA-Pairformer MSAs came from **colabfold-local**,
+not the API. Don't read the API backend and conclude the data is API-sourced.

--- a/src/ecstasy/msa/backends/__init__.py
+++ b/src/ecstasy/msa/backends/__init__.py
@@ -6,9 +6,13 @@ Each backend exposes ``prepare(datasets)``, ``submit(datasets)``, and
 another branch in a shared flow.
 """
 from ecstasy.msa.backends import boltz_csv
-from ecstasy.msa.backends import complex as _complex  # avoid shadowing the builtin
+from ecstasy.msa.backends import complex as _complex          # avoid shadowing the builtin
+from ecstasy.msa.backends import complex_api as _complex_api
 
+# kind -> backend. Two models, two distinct local pipelines — never conflate them
+# (see msa/README.md):
 BACKENDS = {
-    "boltz_csv": boltz_csv,   # Boltz-2: paired+unpaired per-chain CSVs (local colabfold_search)
-    "complex": _complex,      # MSA Pairformer: SI-faithful paired a3m (ColabFold API)
+    "boltz_csv": boltz_csv,       # Boltz-2: LOCAL colabfold_search -> paired+unpaired per-chain CSVs
+    "complex": _complex,          # MSA-Pairformer: LOCAL colabfold-local -> stitched complex a3m  (DEFAULT)
+    "complex_api": _complex_api,  # MSA-Pairformer: ColabFold API fallback (NOT used for the eval data)
 }

--- a/src/ecstasy/msa/backends/_complex_local_driver.py
+++ b/src/ecstasy/msa/backends/_complex_local_driver.py
@@ -1,0 +1,51 @@
+"""Standalone driver — runs INSIDE the colabfold-local venv (no ecstasy imports).
+
+Invoked by the ``complex`` backend's SLURM job. Reads a manifest written by
+``complex.prepare`` and generates each complex MSA via colabfold-local's
+``get_paired_msa_local`` (local colabfold_search), writing each a3m straight to its
+final store path.
+
+  python _complex_local_driver.py <manifest.json>
+
+Requires env: COLABFOLD_LOCAL_DIR (the colabfold-local checkout, so its ``src`` is
+importable), DATA_DIR (local ColabFold DBs), MMSEQS_BIN. Manifest entries are
+``{"seqs": [...], "dst": "<store a3m path>", "header": "<pair_hash>"}``.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    manifest_path = sys.argv[1]
+    cl_dir = os.environ.get("COLABFOLD_LOCAL_DIR")
+    if not cl_dir:
+        print("[complex-local] COLABFOLD_LOCAL_DIR not set", file=sys.stderr)
+        return 2
+    sys.path.insert(0, str(Path(cl_dir) / "src"))
+    from local_msa_adapter import get_paired_msa_local  # noqa: E402  (colabfold-local)
+
+    items = json.loads(Path(manifest_path).read_text())
+    ok = skip = err = 0
+    for it in items:
+        dst = Path(it["dst"])
+        if dst.exists():
+            skip += 1
+            continue
+        try:
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            get_paired_msa_local(sequences=it["seqs"], output_path=dst, use_cache=True)
+            ok += 1
+        except Exception as e:  # noqa: BLE001 — one bad complex must not kill the batch
+            err += 1
+            print(f"[complex-local] ERROR {it.get('header')}: {e}", file=sys.stderr, flush=True)
+        n = ok + skip + err
+        if n % 25 == 0 or n == len(items):
+            print(f"[complex-local] {n}/{len(items)} (wrote={ok} skip={skip} err={err})", flush=True)
+    print(f"[complex-local] DONE wrote={ok} skipped={skip} errors={err}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ecstasy/msa/backends/complex.py
+++ b/src/ecstasy/msa/backends/complex.py
@@ -1,115 +1,151 @@
-"""complex MSA backend — SI-faithful MSA Pairformer paired MSA via the ColabFold API.
+"""complex MSA backend — LOCAL MSA-Pairformer paired MSA via softnanolab/colabfold-local.
 
-Reproduces the MSA Pairformer notebook/SI MMseqs2 route (separate from boltz_csv):
-  heterodimer -> /ticket/pair paircomplete-pairfilterprox_20 -> save_msa filters
-                 (coverage>=0.75, query-identity>=0.30, genomic-distance<=20) -> stitch
-  homodimer   -> /ticket/msa unpaired -> tile each row (s|s)
-Writes one ``#L1,L2\\t1,1``-headed a3m per complex to the store; the depth cap (512,
-hhfilter) happens at model load in the runner. Needs network egress to
-api.colabfold.com — run on a node with internet (login or internet-capable compute).
+This is how the benchmark's MSA-Pairformer MSAs were actually generated — NOT the
+ColabFold API (that's the separate ``complex_api`` backend). Pipeline: colabfold-local's
+``get_paired_msa_local()`` runs local ``colabfold_search`` (mmseqs-gpu) against
+``COLABFOLD_DBS`` and stitches one ``#L1,L2\\t1,1``-headed complex a3m per pair into the
+store. The paired-sequence filter + chain-aware diversity selection + depth cap (512)
+happen later, at model load in ``msa_pairformer_runner.py`` — not here.
 
-Backend interface: ``prepare(datasets) -> Path``, ``submit(datasets) -> None``
-(fetches inline, concurrently), ``ingest(datasets, out_dir=None) -> None`` (reports
-coverage; the fetch writes straight to the store).
+Do NOT confuse this with ``boltz_csv`` (Boltz-2): same search engine, but boltz_csv keeps
+paired+unpaired per-chain CSVs to reproduce ``boltz --use_msa_server``, whereas this
+emits a single stitched complex a3m for MSA-Pairformer. See ``msa/README.md``.
+
+Needs a GPU node + a colabfold-local checkout (the ``third_party/colabfold-local``
+submodule, or ``$COLABFOLD_LOCAL_DIR``) and its venv (``$COLABFOLD_LOCAL_VENV``),
+pinned at the SHA recorded in ``msa/README.md``.
+
+Backend interface: ``prepare(datasets) -> Path``, ``submit(datasets) -> job|None``
+(sbatch), ``ingest(datasets, out_dir=None) -> None`` (copy a3ms into the store).
 """
 from __future__ import annotations
 
-import sys
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import json
+import subprocess
 from pathlib import Path
 
-from ecstasy.config import env_value
-from ecstasy.msa import colabfold as _cf
+from ecstasy.config import env_value, settings
 from ecstasy.msa import store
 from ecstasy.msa.backends._common import collect_complexes, work_dir
+from ecstasy.msa.backends.boltz_csv import _colabfold_paths  # shared mmseqs/dbs/cuda/partition
+
+_DRIVER = Path(__file__).resolve().parent / "_complex_local_driver.py"
 
 
-def _header_and_rows(session, seqs: list[str]) -> tuple[str, list[tuple[str, str]]]:
-    cleaned = [_cf.clean_sequence(s) for s in seqs]
-    lengths = ",".join(str(len(s)) for s in cleaned)
-    header = f"#{lengths}\t{','.join('1' for _ in cleaned)}"
-    uniq = list(dict.fromkeys(cleaned))
-    if len(uniq) == 1:
-        # homodimer/homo-oligomer: tile the single-chain unpaired MSA
-        jid = _cf.submit_msa(session, _cf.make_query_fasta([uniq[0]]), mode="env")
-        _cf.poll_until_done(session, jid)
-        chain_seqs = _cf.parse_unpaired_a3m_bytes(_cf.download_results(session, jid))
-        L, n = len(uniq[0]), len(cleaned)
-        rows = [("query" if i == 0 else f"hom{i}", s * n)
-                for i, s in enumerate(chain_seqs) if len(s) == L]
-        return header, rows
-    # heterodimer: paired prox_20 + save_msa filters + stitch
-    jid = _cf.submit_pair(session, _cf.make_query_fasta(cleaned), mode=_cf.DEFAULT_MODE)
-    _cf.poll_until_done(session, jid)
-    per_chain = _cf.parse_paired_a3m_bytes(_cf.download_results(session, jid), extract_metadata=True)
-    rows, _stats = _cf.apply_save_msa_filters(per_chain, [len(s) for s in cleaned], _cf.SaveMsaFilters())
-    return header, rows
+def _colabfold_local_dir() -> Path:
+    """Resolve the colabfold-local checkout: $COLABFOLD_LOCAL_DIR, else the in-repo
+    submodule, else ~/colabfold-local (documented fallback)."""
+    explicit = env_value("COLABFOLD_LOCAL_DIR")
+    if explicit:
+        return Path(explicit)
+    repo_root = Path(__file__).resolve().parents[4]   # …/src/ecstasy/msa/backends/complex.py -> repo
+    sub = repo_root / "third_party" / "colabfold-local"
+    if sub.exists():
+        return sub
+    return Path.home() / "colabfold-local"
 
 
-def _fetch_one(v: dict) -> int:
-    """Fetch+filter+stitch one complex into the store; -1 if already present."""
-    import requests
-    dst = store.path_for_pair(v["seqs"])
-    if dst.exists():
-        return -1
-    header, rows = _header_and_rows(requests.Session(), v["seqs"])
-    dst.parent.mkdir(parents=True, exist_ok=True)
-    tmp = dst.with_suffix(".a3m.tmp")          # write-then-rename so partials never look "done"
-    with tmp.open("w") as f:
-        f.write(header + "\n")
-        for hdr, seq in rows:
-            f.write(f">{hdr}\n{seq}\n")
-    tmp.rename(dst)
-    return len(rows)
+def _colabfold_local_venv(cl_dir: Path) -> str:
+    explicit = env_value("COLABFOLD_LOCAL_VENV")
+    if explicit:
+        return explicit
+    for cand in (".venv", "venv", ".venv-colabfold"):
+        if (cl_dir / cand / "bin" / "activate").exists():
+            return str(cl_dir / cand)
+    return str(cl_dir / ".venv")
+
+
+def _manifest_path() -> Path:
+    return work_dir("complex") / "manifest.json"
 
 
 def prepare(datasets: list[str]) -> Path:
-    """List store-missing complexes (writes a FASTA for reference)."""
+    """List store-missing complexes; write a reference FASTA + a driver manifest."""
     store.complex_dir().mkdir(parents=True, exist_ok=True)
     items = collect_complexes(datasets)
     missing = {h: v for h, v in items.items() if not store.path_for_pair(v["seqs"]).exists()}
-    work = work_dir("complex"); work.mkdir(parents=True, exist_ok=True)
+    work = work_dir("complex")
+    work.mkdir(parents=True, exist_ok=True)
     fasta = work / "missing.fasta"
     with fasta.open("w") as f:
         for h, v in sorted(missing.items()):
-            f.write(f">{v['header']}\n{v['query']}\n")
+            f.write(f">{v['header']}\n{v['query']}\n")   # query == 'seqA:seqB' (colabfold-local format)
+    manifest = [{"seqs": v["seqs"], "header": v["header"],
+                 "dst": str(store.path_for_pair(v["seqs"]))} for v in missing.values()]
+    _manifest_path().write_text(json.dumps(manifest))
     print(f"[msa:complex] datasets={datasets}")
     print(f"[msa:complex] unique={len(items)} already_in_store={len(items)-len(missing)} missing={len(missing)}")
-    print(f"[msa:complex] wrote {fasta}; run --phase submit to fetch from api.colabfold.com (needs network)")
+    print(f"[msa:complex] wrote {fasta} + manifest; --phase submit sbatches colabfold-local (local, GPU)")
     return fasta
 
 
-def submit(datasets: list[str]) -> None:
-    """Fetch missing complexes from the ColabFold API into the store, concurrently.
+def _write_sbatch() -> Path:
+    p = _colabfold_paths()
+    cl_dir = _colabfold_local_dir()
+    cl_venv = _colabfold_local_venv(cl_dir)
+    work = work_dir("complex")
+    (work / "logs").mkdir(parents=True, exist_ok=True)
+    script = work / "generate_complex.sbatch"
+    script.write_text(f"""#!/usr/bin/env bash
+#SBATCH --job-name=ecstasy-msa-complex
+#SBATCH --output={work}/logs/msa_%j.out
+#SBATCH --error={work}/logs/msa_%j.err
+#SBATCH --gpus-per-node=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=32
+#SBATCH --time=12:00:00
+#SBATCH --partition={p['partition']}
+set -euo pipefail
 
-    Resumable (skips complexes already present), tolerant of per-complex errors.
-    ``COMPLEX_FETCH_WORKERS`` (default 4) concurrent API jobs; each colabfold call
-    backs off on 429, so modest concurrency stays polite.
-    """
-    workers = int(env_value("COMPLEX_FETCH_WORKERS", "4"))
-    items = collect_complexes(datasets)
-    store.complex_dir().mkdir(parents=True, exist_ok=True)
-    missing = [v for v in items.values() if not store.path_for_pair(v["seqs"]).exists()]
-    print(f"[msa:complex] fetching {len(missing)} of {len(items)} complexes "
-          f"from api.colabfold.com ({workers} workers)", flush=True)
-    done = errors = 0
-    with ThreadPoolExecutor(max_workers=workers) as ex:
-        futs = {ex.submit(_fetch_one, v): v["header"] for v in missing}
-        for n, fut in enumerate(as_completed(futs), 1):
-            h = futs[fut]
-            try:
-                if fut.result() >= 0:
-                    done += 1
-            except Exception as e:  # noqa: BLE001
-                errors += 1
-                print(f"[msa:complex] ERROR {h}: {e}", file=sys.stderr, flush=True)
-            if n % 25 == 0 or n == len(missing):
-                print(f"[msa:complex] {n}/{len(missing)} (done={done} errors={errors})", flush=True)
-    print(f"[msa:complex] done: wrote={done} errors={errors}")
+module load {p['cuda_module']}
+# colabfold-local venv (get_paired_msa_local deps); .venv-colabfold supplies colabfold_search.
+# shellcheck disable=SC1091
+source "{cl_venv}/bin/activate"
+export PATH="{p['venv']}/bin:$PATH"
+export COLABFOLD_LOCAL_DIR="{cl_dir}"
+export DATA_DIR="{p['dbs']}"      # local ColabFold DBs (override colabfold-local's default)
+export MMSEQS_BIN="{p['mmseqs']}" # ecstasy's vendored mmseqs-gpu
+
+python "{_DRIVER}" "{_manifest_path()}"
+echo "DONE complex (colabfold-local) MSA generation"
+""")
+    return script
+
+
+def submit(datasets: list[str]) -> str | None:
+    """prepare(), then sbatch the local colabfold-local generation (GPU)."""
+    fasta = prepare(datasets)
+    if fasta.stat().st_size == 0:
+        print("[msa:complex] nothing missing; store is complete")
+        return None
+    script = _write_sbatch()
+    res = subprocess.run(["sbatch", "--parsable", str(script)],
+                         capture_output=True, text=True, check=True)
+    job = res.stdout.strip()
+    print(f"[msa:complex] submitted job {job} ({script}); writes straight to the store. "
+          f"--phase ingest afterwards only verifies coverage.")
+    return job
 
 
 def ingest(datasets: list[str], out_dir: str | None = None) -> None:
-    """Report store coverage (the fetch in `submit` writes straight to the store)."""
+    """Copy externally-generated a3ms into the store, or report coverage.
+
+    If ``out_dir`` is given (e.g. a manual ``colabfold-local`` run, a3ms named
+    ``<pair_hash>.a3m``), copy any matching missing complexes into the store. The
+    sbatch path in ``submit`` writes straight to the store, so it needs no copy.
+    """
     items = collect_complexes(datasets)
+    copied = 0
+    if out_dir:
+        src = Path(out_dir)
+        for v in items.values():
+            dst = store.path_for_pair(v["seqs"])
+            cand = src / f"{v['header']}.a3m"
+            if not dst.exists() and cand.exists():
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                dst.write_text(cand.read_text())
+                copied += 1
     have = sum(1 for v in items.values() if store.path_for_pair(v["seqs"]).exists())
+    if out_dir:
+        print(f"[msa:complex] copied {copied} a3ms from {out_dir}")
     print(f"[msa:complex] store coverage: {have}/{len(items)} complexes")

--- a/src/ecstasy/msa/backends/complex_api.py
+++ b/src/ecstasy/msa/backends/complex_api.py
@@ -1,0 +1,120 @@
+"""complex_api MSA backend — MSA-Pairformer paired MSA via the public ColabFold API.
+
+⚠️  NOT how the benchmark's MSA-Pairformer MSAs were actually generated. The eval
+used the LOCAL ``complex`` backend (``complex.py`` → softnanolab/colabfold-local).
+This API path is kept as a network fallback / cross-check only. See ``msa/README.md``
+for the model→pipeline map and why the two must not be conflated.
+
+Reproduces the MSA Pairformer notebook/SI MMseqs2 route over the network (separate from boltz_csv):
+  heterodimer -> /ticket/pair paircomplete-pairfilterprox_20 -> save_msa filters
+                 (coverage>=0.75, query-identity>=0.30, genomic-distance<=20) -> stitch
+  homodimer   -> /ticket/msa unpaired -> tile each row (s|s)
+Writes one ``#L1,L2\\t1,1``-headed a3m per complex to the store; the depth cap (512,
+hhfilter) happens at model load in the runner. Needs network egress to
+api.colabfold.com — run on a node with internet (login or internet-capable compute).
+
+Backend interface: ``prepare(datasets) -> Path``, ``submit(datasets) -> None``
+(fetches inline, concurrently), ``ingest(datasets, out_dir=None) -> None`` (reports
+coverage; the fetch writes straight to the store).
+"""
+from __future__ import annotations
+
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+from ecstasy.config import env_value
+from ecstasy.msa import colabfold as _cf
+from ecstasy.msa import store
+from ecstasy.msa.backends._common import collect_complexes, work_dir
+
+
+def _header_and_rows(session, seqs: list[str]) -> tuple[str, list[tuple[str, str]]]:
+    cleaned = [_cf.clean_sequence(s) for s in seqs]
+    lengths = ",".join(str(len(s)) for s in cleaned)
+    header = f"#{lengths}\t{','.join('1' for _ in cleaned)}"
+    uniq = list(dict.fromkeys(cleaned))
+    if len(uniq) == 1:
+        # homodimer/homo-oligomer: tile the single-chain unpaired MSA
+        jid = _cf.submit_msa(session, _cf.make_query_fasta([uniq[0]]), mode="env")
+        _cf.poll_until_done(session, jid)
+        chain_seqs = _cf.parse_unpaired_a3m_bytes(_cf.download_results(session, jid))
+        L, n = len(uniq[0]), len(cleaned)
+        rows = [("query" if i == 0 else f"hom{i}", s * n)
+                for i, s in enumerate(chain_seqs) if len(s) == L]
+        return header, rows
+    # heterodimer: paired prox_20 + save_msa filters + stitch
+    jid = _cf.submit_pair(session, _cf.make_query_fasta(cleaned), mode=_cf.DEFAULT_MODE)
+    _cf.poll_until_done(session, jid)
+    per_chain = _cf.parse_paired_a3m_bytes(_cf.download_results(session, jid), extract_metadata=True)
+    rows, _stats = _cf.apply_save_msa_filters(per_chain, [len(s) for s in cleaned], _cf.SaveMsaFilters())
+    return header, rows
+
+
+def _fetch_one(v: dict) -> int:
+    """Fetch+filter+stitch one complex into the store; -1 if already present."""
+    import requests
+    dst = store.path_for_pair(v["seqs"])
+    if dst.exists():
+        return -1
+    header, rows = _header_and_rows(requests.Session(), v["seqs"])
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dst.with_suffix(".a3m.tmp")          # write-then-rename so partials never look "done"
+    with tmp.open("w") as f:
+        f.write(header + "\n")
+        for hdr, seq in rows:
+            f.write(f">{hdr}\n{seq}\n")
+    tmp.rename(dst)
+    return len(rows)
+
+
+def prepare(datasets: list[str]) -> Path:
+    """List store-missing complexes (writes a FASTA for reference)."""
+    store.complex_dir().mkdir(parents=True, exist_ok=True)
+    items = collect_complexes(datasets)
+    missing = {h: v for h, v in items.items() if not store.path_for_pair(v["seqs"]).exists()}
+    work = work_dir("complex"); work.mkdir(parents=True, exist_ok=True)
+    fasta = work / "missing.fasta"
+    with fasta.open("w") as f:
+        for h, v in sorted(missing.items()):
+            f.write(f">{v['header']}\n{v['query']}\n")
+    print(f"[msa:complex] datasets={datasets}")
+    print(f"[msa:complex] unique={len(items)} already_in_store={len(items)-len(missing)} missing={len(missing)}")
+    print(f"[msa:complex] wrote {fasta}; run --phase submit to fetch from api.colabfold.com (needs network)")
+    return fasta
+
+
+def submit(datasets: list[str]) -> None:
+    """Fetch missing complexes from the ColabFold API into the store, concurrently.
+
+    Resumable (skips complexes already present), tolerant of per-complex errors.
+    ``COMPLEX_FETCH_WORKERS`` (default 4) concurrent API jobs; each colabfold call
+    backs off on 429, so modest concurrency stays polite.
+    """
+    workers = int(env_value("COMPLEX_FETCH_WORKERS", "4"))
+    items = collect_complexes(datasets)
+    store.complex_dir().mkdir(parents=True, exist_ok=True)
+    missing = [v for v in items.values() if not store.path_for_pair(v["seqs"]).exists()]
+    print(f"[msa:complex] fetching {len(missing)} of {len(items)} complexes "
+          f"from api.colabfold.com ({workers} workers)", flush=True)
+    done = errors = 0
+    with ThreadPoolExecutor(max_workers=workers) as ex:
+        futs = {ex.submit(_fetch_one, v): v["header"] for v in missing}
+        for n, fut in enumerate(as_completed(futs), 1):
+            h = futs[fut]
+            try:
+                if fut.result() >= 0:
+                    done += 1
+            except Exception as e:  # noqa: BLE001
+                errors += 1
+                print(f"[msa:complex] ERROR {h}: {e}", file=sys.stderr, flush=True)
+            if n % 25 == 0 or n == len(missing):
+                print(f"[msa:complex] {n}/{len(missing)} (done={done} errors={errors})", flush=True)
+    print(f"[msa:complex] done: wrote={done} errors={errors}")
+
+
+def ingest(datasets: list[str], out_dir: str | None = None) -> None:
+    """Report store coverage (the fetch in `submit` writes straight to the store)."""
+    items = collect_complexes(datasets)
+    have = sum(1 for v in items.values() if store.path_for_pair(v["seqs"]).exists())
+    print(f"[msa:complex] store coverage: {have}/{len(items)} complexes")

--- a/src/ecstasy/msa/generate.py
+++ b/src/ecstasy/msa/generate.py
@@ -4,9 +4,15 @@ Backends live in ``msa/backends/`` (one module per ``kind``), each exposing
 ``prepare``/``submit``/``ingest``. This module is just the registry + dispatch:
 
   prepare(datasets, kind)  collect store-missing complexes, write a work FASTA.
-  submit(datasets, kind)   launch generation (SLURM for boltz_csv; inline ColabFold
-                           API fetch for complex).
+  submit(datasets, kind)   launch generation. LOCAL routes sbatch a GPU job:
+                           boltz_csv (colabfold_search) and complex (colabfold-local).
+                           complex_api is the only network route (inline ColabFold API).
   ingest(datasets, kind)   assemble/verify the generated MSAs into the store.
+
+kinds: boltz_csv -> Boltz-2 (per-chain CSVs); complex -> MSA-Pairformer (local
+colabfold-local; the default + how the eval data was made); complex_api -> API
+fallback. boltz_csv and complex use the SAME search engine but produce different
+outputs for different models — never conflate them. See msa/README.md.
 
 Add a kind = add a backend module + one ``BACKENDS`` entry; no new branches here.
 """

--- a/src/ecstasy/pipeline.py
+++ b/src/ecstasy/pipeline.py
@@ -67,7 +67,7 @@ def make_run(dataset: str, model: str, preset: str | None = None,
                model=load_model(model, preset=preset, overrides=overrides))
 
 
-def run_predict(run: Run, limit: int | None = None) -> None:
+def run_predict(run: Run, limit: int | None = None, profile: bool = False) -> None:
     run.write_params()
     n = 0
     for entry in run.dataset.entries():
@@ -75,8 +75,12 @@ def run_predict(run: Run, limit: int | None = None) -> None:
             break
         n += 1
         out_dir = run.predictions_dir / entry.id
-        if (out_dir / "contact.npz").exists():
-            print(f"[skip] {entry.id} (contact.npz exists)")
+        # In profile mode a prior non-profile run may have left contact.npz without
+        # flops.json — don't skip until both exist.
+        done = (out_dir / "contact.npz").exists() and (
+            not profile or (out_dir / "flops.json").exists())
+        if done:
+            print(f"[skip] {entry.id} ({'contact.npz+flops.json' if profile else 'contact.npz'} exists)")
             continue
         msa = store.lookup(entry, run.model.msa) if run.model.needs_msa else None
         if run.model.needs_msa and not msa:
@@ -84,7 +88,7 @@ def run_predict(run: Run, limit: int | None = None) -> None:
                   file=sys.stderr)
         print(f"[predict] {entry.id} -> {out_dir/'contact.npz'}")
         try:
-            predict_one(run.model, entry, msa, out_dir)
+            predict_one(run.model, entry, msa, out_dir, profile=profile)
         except Exception as e:  # noqa: BLE001
             print(f"[error] {entry.id}: {e}", file=sys.stderr)
     print(f"\nDone. processed {n} entries -> {run.predictions_dir}")
@@ -143,8 +147,38 @@ def run_score(run: Run, limit: int | None = None) -> None:
     print(f"result -> {run.result_path}")
 
 
+def flops_summary(run_dir: Path) -> dict | None:
+    """Aggregate per-protein ``flops.json`` sidecars under ``run_dir/predictions``.
+
+    Returns the dataset-mean FLOPs (the x-coordinate paired with mean-P@K) plus
+    median and the 10/90 percentiles for the horizontal whisker (plan §3, §4), or
+    ``None`` if no sidecars exist. FLOPs are true FLOPs = 2*MACs.
+    """
+    vals = []
+    for fp in (run_dir / "predictions").glob("*/flops.json"):
+        try:
+            vals.append(float(json.loads(fp.read_text())["flops"]))
+        except (json.JSONDecodeError, KeyError, OSError):
+            continue
+    if not vals:
+        return None
+    a = np.array(vals)
+    return {
+        "n_flops": int(a.size),
+        "mean_flops": float(a.mean()),
+        "median_flops": float(np.median(a)),
+        "p10_flops": float(np.percentile(a, 10)),
+        "p90_flops": float(np.percentile(a, 90)),
+    }
+
+
 def run_compare(dataset: str) -> None:
-    """Aggregate every run's result.json for a dataset into a CSV + Markdown table."""
+    """Aggregate every run's result.json for a dataset into a CSV + Markdown table.
+
+    When a run also has per-protein ``flops.json`` sidecars (from ``run --profile``),
+    its dataset-mean inference FLOPs are folded in as the x-axis for the
+    P@K-vs-FLOPs plot.
+    """
     root = settings().runs_root / dataset
     files = sorted(root.glob("*/*/result.json"))
     if not files:
@@ -157,6 +191,7 @@ def run_compare(dataset: str) -> None:
         if "mean" not in summary:
             continue
         mean, median = summary["mean"], summary.get("median", {})
+        fl = flops_summary(p.parent) or {}
         rows.append({
             "model": data.get("model", p.parts[-3]),
             "variant": data.get("variant", p.parts[-2]),
@@ -168,6 +203,9 @@ def run_compare(dataset: str) -> None:
             "mean_P@K/2": mean.get("P@K/2", float("nan")),
             "mean_P@K/5": mean.get("P@K/5", float("nan")),
             "mean_AUC": mean.get("AUC", float("nan")),
+            "mean_flops": fl.get("mean_flops", float("nan")),
+            "median_flops": fl.get("median_flops", float("nan")),
+            "n_flops": fl.get("n_flops", 0),
         })
     if not rows:
         print(f"no result.json with summary metrics under {root}", file=sys.stderr)
@@ -175,7 +213,8 @@ def run_compare(dataset: str) -> None:
     rows.sort(key=lambda r: r["mean_P@K"], reverse=True)
 
     cols = ["model", "variant", "n", "skipped", "errors",
-            "mean_P@K", "median_P@K", "mean_P@K/2", "mean_P@K/5", "mean_AUC"]
+            "mean_P@K", "median_P@K", "mean_P@K/2", "mean_P@K/5", "mean_AUC",
+            "mean_flops", "median_flops", "n_flops"]
     csv_path = root / "comparison.csv"
     with csv_path.open("w") as f:
         f.write(",".join(cols) + "\n")
@@ -186,11 +225,14 @@ def run_compare(dataset: str) -> None:
     with md_path.open("w") as f:
         f.write(f"# {dataset} — interchain contact prediction\n\n")
         f.write(f"Aggregated from {len(rows)} run(s) under `{root}`.\n\n")
-        f.write("| model | variant | n | mean P@K | median P@K | P@K/2 | P@K/5 | AUC |\n")
-        f.write("|---|---|---|---|---|---|---|---|\n")
+        f.write("| model | variant | n | mean P@K | median P@K | P@K/2 | P@K/5 | AUC | "
+                "mean GFLOPs | n_flops |\n")
+        f.write("|---|---|---|---|---|---|---|---|---|---|\n")
         for r in rows:
+            gflops = r["mean_flops"] / 1e9
+            gf = f"{gflops:.1f}" if gflops == gflops else "—"   # NaN-safe
             f.write(f"| {r['model']} | {r['variant']} | {r['n']} | {r['mean_P@K']:.4f} | "
                     f"{r['median_P@K']:.4f} | {r['mean_P@K/2']:.4f} | {r['mean_P@K/5']:.4f} | "
-                    f"{r['mean_AUC']:.4f} |\n")
+                    f"{r['mean_AUC']:.4f} | {gf} | {r['n_flops']} |\n")
     print(f"wrote {csv_path}\nwrote {md_path}\n")
     print(md_path.read_text())

--- a/src/ecstasy/registry/datasets.yaml
+++ b/src/ecstasy/registry/datasets.yaml
@@ -28,6 +28,15 @@ val_seq_chain:      # V1 MMseqs cluster @ 30% seq id, chain-level   (631)
 val_seq_pair:       # V2 MMseqs cluster, pair identity              (945)
   <<: *mentos
   index: ${MENTOS_ROOT}/pdb/processed/splits/val_seq_pair/index.parquet
+
+# Chain-order-permutation experiment: val_seq_pair with each dimer's chains flipped
+# (A,B)->(B,A), GT reindexed to match. ISOLATED (own run dir + own pair-hash MSAs, so
+# MSAs get recalculated from scratch for the flipped order). Tests model order-dependence.
+val_seq_pair_swapped:
+  <<: *mentos
+  index: ${MENTOS_ROOT}/pdb/processed/splits/val_seq_pair/index.parquet
+  swap_chains: true
+
 val_pinder_chain:   # V3 depth-2 walk, fused interface-monomer graph (98)
   <<: *mentos
   index: ${MENTOS_ROOT}/pdb/processed/splits/val_pinder_chain/index.parquet

--- a/src/ecstasy/registry/models.yaml
+++ b/src/ecstasy/registry/models.yaml
@@ -2,9 +2,15 @@
 # ${VAR} expands against ecstasy.config.Settings.
 #   runner          script under models/_runners/ run inside `env`
 #   env             venv whose bin/python executes the runner
-#   msa             none | per_chain (unpaired a3m, by seq-hash) | complex (paired a3m, by pair-hash)
-#                   | boltz_csv (paired+unpaired per-chain CSV, by pair-hash; reproduces
-#                     boltz --use_msa_server — a custom .a3m would drop ALL pairing)
+#   msa             none | per_chain (unpaired a3m, by seq-hash)
+#                   | boltz_csv  (Boltz-2: LOCAL colabfold_search -> paired+unpaired per-chain
+#                     CSV, by pair-hash; reproduces boltz --use_msa_server — a custom .a3m would
+#                     drop ALL pairing)
+#                   | complex    (MSA-Pairformer: LOCAL colabfold-local -> stitched complex a3m,
+#                     by pair-hash; how the eval MSAs were made)
+#                   | complex_api(MSA-Pairformer: ColabFold API fallback — NOT used for eval data)
+#                   boltz_csv and complex share the search engine but are DIFFERENT pipelines
+#                   for DIFFERENT models — never conflate. Full map: src/ecstasy/msa/README.md
 #   infra           machine knobs that do NOT affect outputs (excluded from the variant id)
 #   default_preset  preset used when --preset is omitted
 #   presets         named output-affecting parameter sets; pick by name, tweak with --set
@@ -18,6 +24,27 @@ boltz2:
   presets:
     full: {recycling_steps: 3, sampling_steps: 25, diffusion_samples: 1, contact_cutoff_bin: 19}
     fast: {recycling_steps: 1, sampling_steps: 10, diffusion_samples: 1, contact_cutoff_bin: 19}
+    # FLOPs recycle sweep: ONLY recycling_steps varies; sampling/diffusion held at the
+    # `full` defaults so the compute→P@K line isolates the recycle knob (plan §3, §6).
+    r0: {recycling_steps: 0, sampling_steps: 25, diffusion_samples: 1, contact_cutoff_bin: 19}
+    r1: {recycling_steps: 1, sampling_steps: 25, diffusion_samples: 1, contact_cutoff_bin: 19}
+    r3: {recycling_steps: 3, sampling_steps: 25, diffusion_samples: 1, contact_cutoff_bin: 19}
+    r5: {recycling_steps: 5, sampling_steps: 25, diffusion_samples: 1, contact_cutoff_bin: 19}
+
+# Single-sequence Boltz-2 (no MSA): identical runner/presets to boltz2 but msa=none,
+# so the runner emits `msa: empty` per chain. Isolates how much Boltz leans on its MSA
+# (compare to boltz2 at each recycle) and is a clean single-seq baseline.
+boltz2_nomsa:
+  runner: boltz2_runner.py
+  env: ${ENVS_ROOT}/.venv-boltz
+  msa: none
+  infra: {num_workers: 0, devices: 1, no_kernels: true}
+  default_preset: r3
+  presets:
+    r0: {recycling_steps: 0, sampling_steps: 25, diffusion_samples: 1, contact_cutoff_bin: 19}
+    r1: {recycling_steps: 1, sampling_steps: 25, diffusion_samples: 1, contact_cutoff_bin: 19}
+    r3: {recycling_steps: 3, sampling_steps: 25, diffusion_samples: 1, contact_cutoff_bin: 19}
+    r5: {recycling_steps: 5, sampling_steps: 25, diffusion_samples: 1, contact_cutoff_bin: 19}
 
 esmfold:
   runner: esmfold_runner.py
@@ -28,13 +55,28 @@ esmfold:
     # 32-residue poly-G linker + 512 positional-index skip between chains (multimer hack)
     glinker32: {num_recycles: 4, chain_linker_length: 32, residue_index_offset: 512, contact_cutoff_bin: 19}
     full: {num_recycles: 4, chain_linker_length: 25, residue_index_offset: 512, contact_cutoff_bin: 19}
+    # FLOPs recycle sweep: ONLY num_recycles varies; linker/offset held at glinker32.
+    r0: {num_recycles: 0, chain_linker_length: 32, residue_index_offset: 512, contact_cutoff_bin: 19}
+    r1: {num_recycles: 1, chain_linker_length: 32, residue_index_offset: 512, contact_cutoff_bin: 19}
+    r3: {num_recycles: 3, chain_linker_length: 32, residue_index_offset: 512, contact_cutoff_bin: 19}
+    r5: {num_recycles: 5, chain_linker_length: 32, residue_index_offset: 512, contact_cutoff_bin: 19}
 
 mentos:
   runner: mentos_runner.py
   env: ${ENVS_ROOT}/.venv-boltz          # where the mentos package is installed editable
   msa: none
-  default_preset: pretrain_8m_35m
+  default_preset: a5sgd6ul_latest
   presets:
+    # HEADLINE (user-chosen): a5sgd6ul "latest". The still-training run keeps every step
+    # checkpoint (un-pruned), so the latest *step* ckpt == last.ckpt content but is frozen
+    # (won't be rewritten). Config comes from $LOGS_DIR W&B run files (wandb-metadata.json
+    # fallback) via run_id. Pinned to step-96000 (== last.ckpt as of 2026-06-01 07:35,
+    # epoch 3); bump model_weights_path to a newer step before the big job if you want fresher.
+    a5sgd6ul_latest:
+      run_id: a5sgd6ul
+      model_weights_path: /projects/u6jv/harsh/MENTOS_META/LOGS/mentos/a5sgd6ul/checkpoints/epoch=3-step=96000.ckpt
+    # Stale 8M/35M preset (old architecture — MENTOS(cfg) raises Missing key pair_stack).
+    # Kept for provenance; do not use with the current code.
     pretrain_8m_35m:
       model_config_path: /projects/u6jv/harsh/MENTOS_META/LOGS/MINT_AFDD_PRETRAIN_8M_35M/3khmvobe/config.yaml
       model_weights_path: /projects/u6jv/harsh/MENTOS_META/LOGS/MINT_AFDD_PRETRAIN_8M_35M/3khmvobe/checkpoints/last.ckpt

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -37,8 +37,9 @@ def test_unknown_dataset_raises():
 
 
 def test_models_registered_with_presets():
-    assert set(model_names()) == {"boltz2", "esmfold", "mentos", "colabfold", "msa_pairformer"}
-    assert presets_for("boltz2") == ["fast", "full"]
+    assert set(model_names()) == {"boltz2", "boltz2_nomsa", "esmfold", "mentos",
+                                  "colabfold", "msa_pairformer"}
+    assert presets_for("boltz2") == ["fast", "full", "r0", "r1", "r3", "r5"]
 
 
 def test_default_preset_and_variant():
@@ -86,7 +87,8 @@ def test_variant_distinguishes_different_overrides():
 
 def test_msa_backends_registered():
     from ecstasy.msa.backends import BACKENDS
-    assert set(BACKENDS) == {"boltz_csv", "complex"}
+    # boltz_csv (Boltz-2) + complex (MSA-Pairformer local, default) + complex_api (API fallback)
+    assert set(BACKENDS) == {"boltz_csv", "complex", "complex_api"}
     for b in BACKENDS.values():
         assert all(hasattr(b, fn) for fn in ("prepare", "submit", "ingest"))
 


### PR DESCRIPTION
## Summary
- Reframes the eval layer around **inter-chain P@K vs. empirically-measured inference FLOPs** across boltz2 / esmfold / msa_pairformer / mentos (+ a single-seq boltz2 baseline).
- Splits the two MSA-generation pipelines so they can't be conflated: Boltz-2's `boltz_csv` vs MSA-Pairformer's `complex` (now the **local** colabfold-local route; the API path is renamed `complex_api`).
- Adds a chain-order-permutation (swap) eval as an isolated dataset variant.

## Changes
- **FLOPs profiling** — `_flops.py` (torch `FlopCounterMode`, 2×MACs over the contact-dependency subgraph) + `_boltz_profile.py` (in-process boltz trunk-only profiling, structure/diffusion skipped, off-path heads subtracted); `--profile` wired through `adapter.py` / `pipeline.py` and every runner. `models.yaml`: recycle-sweep presets `r0/r1/r3/r5`, `boltz2_nomsa`, mentos `step-96000`.
- **MSA pipelines** — `complex.py` is now the LOCAL backend (colabfold-local via `_complex_local_driver.py`); old API code → `complex_api.py`; registry = `{boltz_csv, complex, complex_api}`. `third_party/colabfold-local` pinned as a submodule. New `src/ecstasy/msa/README.md` + repo `CLAUDE.md` document the two pipelines.
- **Chain-swap eval** — `swap_chains` param on the `mentos_square` loader + `val_seq_pair_swapped` dataset (reverses chain order, reindexes the square GT); `swap_compare.py` / `plot_swap_flops.py`.
- **Figures** — `_plotstyle.py` (CMU Concrete) + `plot_pak_vs_flops` / `plot_flops_vs_length` / `plot_pak_vs_interface` / `plot_pak_vs_msadepth`. All resolve paths from `settings()` (no hardcoded roots).
- **Docs/portability** — `scripts/README.md` documents every workflow with example commands. Per-cluster SLURM `*.sbatch` wrappers are **not committed** (git-ignored).

## Quality gates
- pre-commit: n/a — no `.pre-commit-config.yaml` in the repo
- pytest: **57 passed** (unit suite `tests/` excl. `integration/` + `installation/`, which need GPU + per-model envs; those model-prediction paths were exercised live this session)
- thermo-nuclear review: ran — **0 blockers**, 3 should-fix (2 addressed below), 1 nit
- correctness review: ran — **0 blockers**, swap/FLOPs/MSA logic verified, 3 nits
- tests review: ran — **0 blockers**, 2 should-fix (cheap pure-function tests), 2 nits
- Ran on: compute node, SLURM job `4990910` (login node = login42, gates not run there)

## Addressed from review (before opening)
- ✅ **Dropped all 6 new `*.sbatch` wrappers** (they hardcoded an ephemeral job dir + worktree path) — git-ignored; equivalent portable commands documented in `scripts/README.md`.
- ✅ **De-hardcoded the analysis scripts** — `swap_compare` / `plot_swap_flops` / `plot_pak_vs_msadepth` now use `settings().runs_root`; `_plotstyle` uses `$CMU_FONT_DIR`/`~/.fonts` (no hardcoded home).
- ↪ **Deferred** (in review notes below, non-blocking): hoist `_colabfold_paths` to `backends/_common.py`; add the two cheap pure-function tests (swap-reindex transpose, backend distinctness); the profile-branch helper.

## Thermo-nuclear review
**Verdict: no structural blocker in the package code — the core design is clean.** The MSA work uses one module per `kind` behind a uniform `prepare/submit/ingest` interface (API path cleanly renamed `complex_api`), the chain-swap is a config flag on the existing loader rather than a parallel class, and every changed/new file is well under 1k lines (largest `pipeline.py` at 238).

- **should-fix — committed sbatch scripts hardcode an ephemeral job dir + worktree path.** `scripts/{swap_smoke,swap_full_eval,flops_nomsa_sweep,finalize_nomsa,mentos_eval_sweep,flops_sweep}.sbatch` bake in `…/.claude/jobs/0a242b3c/tmp` (a deleted per-run dir) and a literal worktree path → run for no one else. Remedy: keep them local or parameterize via `$SLURM_SUBMIT_DIR`. *(ADDRESSED — dropped + documented.)*
- **should-fix — cross-backend private import.** `complex.py:30` does `from ecstasy.msa.backends.boltz_csv import _colabfold_paths` — reaching into a sibling backend's underscore helper. Hoist `_colabfold_paths` into `backends/_common.py` (canonical shared layer). *(deferred)*
- **should-fix — three analysis scripts hardcode the data root.** `swap_compare.py:17`, `plot_swap_flops.py:22`, `plot_pak_vs_msadepth.py:26` used a literal `/projects/...` while sibling plot scripts use `settings().runs_root`. *(ADDRESSED.)*
- **nit — profile-branch boilerplate repeated across 3 runners.** A thin `_flops.profiled_forward(thunk, *, L, msa_depth, recycles, out_dir)` would collapse two scattered `if profile` branches per runner into one call site. *(deferred)*
- **Not flagged (intentionally clean):** the `swap_chains` flag (loader param, not subclass), the ecstasy-free `_complex_local_driver.py` (must run in colabfold-local's venv), the isolated/documented `_boltz_profile.py` monkeypatch. No file-size explosion, no spaghetti, no magic abstractions.

## Reviewer notes — Correctness & logic
I read the full diff plus `mentos.py`, `contact.py`, `store.py`, `boltz_csv.py` (assembly), and the new FLOPs/MSA backends. The three headline mechanisms are sound. **No blockers found.**

- **Swap GT reindex (verified correct)** — `_swap_perm(la, L)=[la..L, 0..la)` is applied symmetrically to rows and cols via `np.ix_(perm, perm)` on both `contact_map` and `valid`; `la` is taken from the *original* `sample.sequences[0]` before reassignment, so the permutation matches the unpermuted `.pt` map. `entries()` yields `(B,A)` and the model's `probs` is naturally in `(B,A)` layout, consistent with the reindexed GT. Consistent end-to-end.
- **Boltz off-path subtraction (verified correct)** — `flops = total - off_path`, `off_path ≥ 0`, summed once over root-direct-children whose leaf name is in `OFF_PATH`; `_top_level_breakdown` keeps only depth==root+1 nodes, so no parent/child double-count. Under `skip_run_structure=True` the structure/diffusion subtree is 0 (asserted); confidence/bfactor subtracted exactly once. No sign error.
- **`-1,` paired/unpaired counting (verified correct)** — `not line.startswith("-1,")` matches the assembly convention (unpaired rows keyed `-1`).
- **nit** — `entries()` swaps on `len(row.sequences)==2` (parquet) while `gt_for()` swaps on `len(sample.sequences)==2` (`.pt`); if the two sources disagreed on chain count, input and GT could desync. The score guard degrades this to an `_error` skip, not silent corruption, and it's a pre-existing baseline assumption.
- **nit** — `complex.ingest()` copies an a3m with no `.tmp`+rename (unlike the API path); a truncated source would copy as-is. Low risk (the sbatch driver writes straight to the store).
- **nit** — `esmfold_runner` records `eff_recycles=4` as a hardcoded esm default when `num_recycles is None` (the measured FLOPs count is unaffected).

## Reviewer notes — Tests & coverage
The only test delta is `tests/test_registry.py` (BACKENDS now `{boltz_csv, complex, complex_api}`; `model_names()` includes `boltz2_nomsa`). Keeps the registry smoke-tests green but is **not adequate** for a change this size — the new *logic* (swap reindex, local `complex` backend, FLOPs profiler) ships untested, and two pieces are pure functions that are cheaply testable without a GPU. **No blockers.**

- **should-fix** — `mentos.py` swap reindex is the scientific core and is untested; an off-by-one or wrong `np.ix_` axis would silently transpose/garble the interface. Pure NumPy. Test: assert `gt_swap["contact_map"][lb:, :lb] == gt_orig["contact_map"][:la, la:].T` and that `valid`/`sequences` flip consistently.
- **should-fix** — `test_msa_backends_registered` asserts `complex`/`complex_api` are present but not *distinct* (the whole point of the split). Add `assert BACKENDS["complex"] is not BACKENDS["complex_api"]`.
- **nit** — `_flops._top_level_breakdown` parent/child de-dup is untested pure dict logic; feed a hand-built `flop_counts` and assert only the depth-2 child is kept, `Global` dropped, no double count.
- **nit** — no registry assertion for the `r0/r1/r3/r5` presets or `val_seq_pair_swapped` (`swap_chains is True`); a YAML typo would only surface at GPU-job time.
- **Not blocking:** the runner FLOPs wiring + local `complex` backend genuinely need GPU + model envs and reasonably stay in the un-gated `tests/integration/` tier.

## Test plan
- [ ] `PYTHONPATH=src pytest -q tests/ --ignore=tests/integration --ignore=tests/installation` → 57 passed
- [ ] `ecstasy msa --datasets <split> --kind complex --phase submit` sbatches colabfold-local locally (not the API); `complex_api` is the only network route
- [ ] `load_dataset("val_seq_pair_swapped").swap_chains is True`; swapped GT inter-chain block == transpose of original
- [ ] `git submodule update --init third_party/colabfold-local` resolves to pinned `38088c9`
- [ ] plot scripts run from a clean env with only the `*_ROOT` vars set (no hardcoded paths)

Generated with the SoftNano plugin.
