### PR TITLE
Add ESM2 contact-prediction model (poly-G-linker multimer hack)

### DIFF
--- a/scripts/install/esm2.sh
+++ b/scripts/install/esm2.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Dedicated venv for the ESM2 contact-prediction model (src/ecstasy/models/_runners/esm2_runner.py).
+#
+# ESM2's supervised contact head needs only torch + fair-esm — NOT the openfold/esmfold
+# structure stack — so this is a tiny plain `uv` venv, independent of .venv-esmfold.
+#
+# torch is pinned <2.6 on purpose: fair-esm loads its pretrained checkpoints with a bare
+# `torch.load(..., map_location="cpu")` (no `weights_only=False`). torch>=2.6 flipped that
+# default to True and refuses the argparse Namespace inside the esm checkpoints, breaking
+# `esm.pretrained.esm2_*`. 2.5.1 keeps weights_only=False by default. cu124 wheels run fine
+# on the cluster's newer driver (the mentos env already runs cu130 torch on the same nodes).
+set -euo pipefail
+
+ENVS_ROOT="${ENVS_ROOT:-$(grep -E '^ENVS_ROOT=' "$(dirname "$0")/../../.env" | cut -d= -f2)}"
+VENV="${ENVS_ROOT}/.venv-esm2"
+
+echo "Creating ${VENV} ..."
+uv venv --python 3.12 "${VENV}"
+uv pip install --python "${VENV}/bin/python" \
+  torch==2.5.1 --index-url https://download.pytorch.org/whl/cu124
+uv pip install --python "${VENV}/bin/python" fair-esm numpy
+
+echo "Verifying ESM2 contact head loads ..."
+"${VENV}/bin/python" - <<'PY'
+import torch, esm
+model, alphabet = esm.pretrained.esm2_t6_8M_UR50D()
+bc = alphabet.get_batch_converter()
+_, _, toks = bc([("c", "MKTAYIAKQR" + "G" * 25 + "GGSDFAERTQ")])
+with torch.no_grad():
+    c = model.eval()(toks, return_contacts=True)["contacts"]
+assert c.shape == (1, 45, 45), c.shape
+print("OK", torch.__version__, "contacts", tuple(c.shape))
+PY
+echo "Done: ${VENV}"

--- a/src/ecstasy/models/_runners/esm2_runner.py
+++ b/src/ecstasy/models/_runners/esm2_runner.py
@@ -1,0 +1,112 @@
+"""Self-contained ESM2 contact-prediction runner — invoked via env's python from the
+outer adapter. Runs in its own .venv-esm2 (torch + fair-esm only; see
+scripts/install/esm2.sh) — fair-esm ships every ESM2 size + the contact regression head.
+
+Reads a JSON bundle from stdin:
+  { entry_id, sequences[], chain_ids[], msa_paths{} (ignored), out_dir, params }
+
+Bundle's "params" (all optional):
+  model_name           — fair-esm ESM2 checkpoint name (default esm2_t33_650M_UR50D);
+                         one of esm2_t6_8M / t12_35M / t30_150M / t33_650M / t36_3B _UR50D
+  chain_linker_length  — poly-G linker residues inserted between chains (default 25).
+
+Writes:
+  <out_dir>/contact.npz   — probs (L, L) float16, length int32
+
+ESM2's `predict_contacts` is the supervised contact head from the original ESM repo
+(https://github.com/facebookresearch/esm/blob/main/examples/contact_prediction.ipynb):
+symmetrised + APC-corrected attention maps fed through a logistic-regression head, giving
+a per-residue-pair **contact probability in [0, 1]** (not a distogram, no recycles).
+
+Multimer hack (mirrors ESMFold): the chains are concatenated into one sequence separated
+by a "GGGG…" poly-G linker so the model sees a single L_total = ΣL_i + (k-1)·linker token
+construct. ESM2 uses **rotary (relative) position embeddings**, so unlike ESMFold there is
+no separate absolute residue-index offset to apply — the linker length *is* the positional
+skip between chains. The runner strips the linker positions from the (L_total, L_total)
+contact map to recover an (L, L) matrix over residues only.
+
+We keep the head's continuous probability (the natural contact score) rather than a hard
+0/1: interchain P@K ranks pairs by score and takes the top-K, so a thresholded map would
+make the ranking — and hence P@K — ill-defined among ties.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+def main():
+    bundle = json.loads(sys.stdin.read())
+    sequences: list[str] = bundle["sequences"]
+    out_dir = Path(bundle["out_dir"])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cfg = bundle.get("params") or {}
+
+    model_name: str = str(cfg.get("model_name", "esm2_t33_650M_UR50D"))
+    chain_linker_len: int = int(cfg.get("chain_linker_length", 25))
+    profile = bool(bundle.get("profile"))
+    if profile:
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        import _flops
+
+    import esm
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"[esm2] device={device}  model={model_name}  linker={chain_linker_len}G", flush=True)
+
+    model, alphabet = getattr(esm.pretrained, model_name)()
+    model = model.eval().to(device)
+    batch_converter = alphabet.get_batch_converter()
+
+    linker = "G" * chain_linker_len
+    seq = linker.join(sequences)
+    _, _, tokens = batch_converter([("complex", seq)])
+    tokens = tokens.to(device)
+
+    flops_payload = None
+    with torch.no_grad():
+        if profile:
+            # Single forward, no recycles: the whole contact-head forward IS the
+            # contact-dependency subgraph (see FLOPS_BENCHMARK_PLAN.md §3.5).
+            out, flops_payload = _flops.profile_call(
+                model, tokens, return_contacts=True
+            )
+            contacts = out["contacts"]
+        else:
+            contacts = model(tokens, return_contacts=True)["contacts"]
+
+    # The contact head returns (B, L_total, L_total) already stripped of BOS/EOS,
+    # so positions index directly into `seq`.
+    contact_full = contacts[0].float().cpu().numpy()
+
+    keep: list[int] = []
+    pos = 0
+    for i, s in enumerate(sequences):
+        keep.extend(range(pos, pos + len(s)))
+        pos += len(s)
+        if i < len(sequences) - 1:
+            pos += chain_linker_len
+    keep_arr = np.asarray(keep)
+    contact = contact_full[keep_arr][:, keep_arr].astype(np.float16)
+
+    np.savez_compressed(
+        out_dir / "contact.npz",
+        probs=contact,
+        length=np.int32(contact.shape[0]),
+    )
+    print(f"[esm2] WROTE {out_dir / 'contact.npz'}  shape={contact.shape}", flush=True)
+
+    if profile and flops_payload is not None:
+        sidecar = _flops.write_flops_sidecar(
+            out_dir, flops_payload,
+            L=int(contact.shape[0]), msa_depth=0, recycles=0, model=model_name,
+        )
+        print(f"[esm2] WROTE {sidecar}  flops={flops_payload['flops']:.3e}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ecstasy/registry/models.yaml
+++ b/src/ecstasy/registry/models.yaml
@@ -61,6 +61,26 @@ esmfold:
     r3: {num_recycles: 3, chain_linker_length: 32, residue_index_offset: 512, contact_cutoff_bin: 19}
     r5: {num_recycles: 5, chain_linker_length: 32, residue_index_offset: 512, contact_cutoff_bin: 19}
 
+# ESM2 supervised contact head (facebookresearch/esm contact_prediction.ipynb), adapted
+# for dimers with the same poly-G-linker multimer hack as ESMFold. ESM2 uses rotary
+# (relative) positions, so the linker length *is* the positional skip — there is no
+# separate residue_index_offset. The head emits a contact probability in [0, 1] directly
+# (no distogram, no recycles); we keep the continuous score for P@K ranking. Dedicated
+# lightweight venv: just torch + fair-esm (no openfold/esmfold stack), built by
+# scripts/install/esm2.sh. torch pinned <2.6 so fair-esm's checkpoint torch.load (which
+# omits weights_only=False) keeps working. Presets sweep model SIZE → the compute→P@K curve (analogous to the recycle sweeps).
+esm2:
+  runner: esm2_runner.py
+  env: ${ENVS_ROOT}/.venv-esm2
+  msa: none
+  default_preset: t33_650M
+  presets:
+    t6_8M:    {model_name: esm2_t6_8M_UR50D,    chain_linker_length: 25}
+    t12_35M:  {model_name: esm2_t12_35M_UR50D,  chain_linker_length: 25}
+    t30_150M: {model_name: esm2_t30_150M_UR50D, chain_linker_length: 25}
+    t33_650M: {model_name: esm2_t33_650M_UR50D, chain_linker_length: 25}
+    t36_3B:   {model_name: esm2_t36_3B_UR50D,   chain_linker_length: 25}
+
 mentos:
   runner: mentos_runner.py
   env: ${ENVS_ROOT}/.venv-mentos         # dedicated venv; mentos installed editable from /home/.../mentos

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -38,8 +38,18 @@ def test_unknown_dataset_raises():
 
 def test_models_registered_with_presets():
     assert set(model_names()) == {"boltz2", "boltz2_nomsa", "esmfold", "mentos",
-                                  "colabfold", "msa_pairformer"}
+                                  "colabfold", "msa_pairformer", "esm2"}
     assert presets_for("boltz2") == ["fast", "full", "r0", "r1", "r3", "r5"]
+    # esm2 sweeps model size (no recycles); presets are the fair-esm size tiers.
+    assert presets_for("esm2") == ["t12_35M", "t30_150M", "t33_650M", "t36_3B", "t6_8M"]
+
+
+def test_esm2_default_preset_and_params():
+    m = load_model("esm2")
+    assert m.preset == "t33_650M" and m.variant == "t33_650M"
+    assert m.params["model_name"] == "esm2_t33_650M_UR50D"
+    assert m.params["chain_linker_length"] == 25
+    assert m.msa == "none" and not m.needs_msa
 
 
 def test_default_preset_and_variant():


### PR DESCRIPTION
## Summary
- Adds an `esm2` contact-prediction model that benchmarks ESM2's supervised contact head (facebookresearch/esm `contact_prediction.ipynb`) for inter-chain P@K, alongside the existing structure models.
- Multimer hack mirrors ESMFold: chains are concatenated with a poly-G linker. Because ESM2 uses **rotary (relative) position embeddings**, the linker length *is* the positional skip — there is no separate `residue_index_offset`.
- The head emits a contact probability in `[0,1]` directly (no distogram, no recycles); the continuous score is kept (not thresholded to 0/1) because inter-chain P@K ranks pairs by score.

## Changes
- `src/ecstasy/models/_runners/esm2_runner.py`: new self-contained runner (stdin JSON bundle → `predict_contacts` on the linker-joined dimer → strip linker positions → `contact.npz` `{probs (L,L) float16, length int32}`, plus optional `flops.json` via the shared `_flops.py`). Closely follows `esmfold_runner.py`.
- `src/ecstasy/registry/models.yaml`: new `esm2` row, `msa: none`, default preset `t33_650M`, size-sweep presets `t6_8M … t36_3B` (these double as a compute→P@K curve).
- `scripts/install/esm2.sh`: builds a dedicated lightweight `.venv-esm2` (torch + fair-esm only; **torch pinned 2.5.1** so fair-esm's checkpoint `torch.load`, which omits `weights_only=False`, keeps working on torch ≥2.6's flipped default).
- `tests/test_registry.py`: register `esm2` in the models-set snapshot, assert its presets, add `test_esm2_default_preset_and_params`.

Validated end-to-end out of band: full predict+score on `val_seq_pair` (965 dimers) and `val_pinder_pair` (486) for the 150M and 650M presets, with FLOPs sidecars.

## Quality gates
- pre-commit: n/a (no `.pre-commit-config.yaml` in repo)
- pytest: **58 passed, 23 deselected** (`installation`/`integration`/`gpu`/`slow` markers — they need model downloads + GPU), exit 0
- thermo-nuclear review: ran — **0 blockers, 1 should-fix, 2 nits**
- Ran on: SLURM compute node `node-c12e-012.young.ucl.ac.uk` (`.venv-ecstasy` + `PYTHONPATH=<worktree>/src`)

## Thermo-nuclear review
**Verdict: APPROVE (no blockers).** Clean, self-contained additive model. No file approaches 1k lines (largest new file 112 lines), no new branching bolted onto existing flows, logic lives in the correct layer (`_runners/` + a declarative `models.yaml` row), and it faithfully mirrors the established runner contract in `esmfold_runner.py`.

1. **should-fix — duplicated linker-strip logic across runners.** `esm2_runner.py` re-implements the poly-G linker-position strip (`keep`/`pos` loop) verbatim from `esmfold_runner.py:90-97`. There's already a precedent for sharing pure helpers across the venv-isolated runners — `_flops.py` is imported via `sys.path.insert(Path(__file__).parent)`. Extract the strip into a `_runners/_linker.py` with a pure `keep_indices(seq_lengths, linker_len) -> np.ndarray` (numpy-only, so unit-testable from `.venv-ecstasy`) and have both runners use it. *Not a blocker:* the duplication is ~8 lines and de-duping requires touching the in-production `esmfold_runner.py`, so it's reasonable to land esm2 first and do the extraction as a focused follow-up — but it should be tracked.
2. **nit — `getattr(esm.pretrained, model_name)` dynamic dispatch.** Superficially "magic", but `model_name` is constrained by the registry presets so the boundary is explicit and this is the idiomatic fair-esm entry point. Fine as-is.
3. **nit — sibling-runner consistency.** `esm2_runner.py` doesn't bind `entry_id` from the bundle (esmfold uses it in log lines). Harmless.

No spaghetti growth, no boundary leaks, no file-size explosion, no unnecessary abstraction/casts. Registry row + install script follow existing conventions exactly.

## Reviewer notes — Correctness & logic
**No correctness/logic blockers found.** Verified against `esmfold_runner.py`, `_flops.py`, `metrics/contact.py`, `datasets/mentos.py`, and the installed fair-esm source.

- **Linker-strip math**: identical to `esmfold_runner.py:90-97`. `keep` walks chains, appends each chain's residue range, skips `chain_linker_len` between (not after the last) chains. Correct for any k chains, no off-by-one. Resulting `(L,L)` has chain order A-then-B with `L=Σlenᵢ`, exactly what `mentos.py` expects (`chain_ids = [0]*la + [1]*lb`).
- **BOS/EOS stripping**: confirmed against installed `esm/modules.py` `ContactPredictionHead.forward` (strips EOS then BOS), so the returned `(B, L_total, L_total)` indexes directly into `seq`. `batch_converter` is created with no `truncation_seq_length`, so long dimers aren't silently truncated (which would desync `keep`).
- **Profile branch**: `_flops.profile_call` returns `(result, payload)`; `result` is the model output dict, so `out["contacts"]` matches the non-profile `model(...)["contacts"]`. `write_flops_sidecar` signature matches.
- **float16 / metrics**: `mentos.py` reloads `probs` as float32 and ranks over the strict-upper-triangle inter-chain pairs — float16 precision loss is immaterial to ranking; the self-diagonal never enters the metric.

Nits: doesn't bind `entry_id` (harmless); single-chain bundle yields zero inter-chain pairs but `mentos.py` already returns `{"_skipped": "non-dimer"}` (no crash); install-script self-check asserts the correct `(1,45,45)` shape.

## Reviewer notes — Tests & coverage
**No blockers.** The `tests/test_registry.py` changes are correct (sorted preset order, default `t33_650M`, `msa none`, linker 25 all match the registry), but the PR omits the established per-model test scaffolding:

- **should-fix — missing `tests/installation/test_venv_esm2.py`**: every model venv has an installation import smoke (`test_venv_esmfold.py` subprocess-imports torch+esm+ecstasy via the `run_in_venv` fixture); `.venv-esm2` has none. Also register `"esm2"` in `conftest.py`'s `VENVS` dict (currently absent → `run_in_venv("esm2")` would KeyError).
- **should-fix — missing `tests/integration/test_predict_esm2.py`**: every runnable model has an end-to-end predict smoke (`test_predict_esmfold.py` runs `ecstasy run --limit 1 --no_score` and asserts a valid `contact.npz`); esm2's stdin-bundle path, linker-strip, and npz output are untested. Use the smallest `t6_8M` preset to stay cheap; mark `@integration @gpu @model_esm2`.
- **should-fix — `pyproject.toml` markers**: registers `model_boltz2/mentos/esmfold/msa_pairformer/colabfold` but no `model_esm2`; add `"model_esm2: esm2 predict smoke"` for the integration test above.
- **nit**: extract the linker-strip into a pure `_keep_indices(seq_lengths, linker_len)` so it can be unit-tested without the venv (overlaps with the thermo-nuclear should-fix).
- **nit**: `test_esm2_default_preset_and_params` only checks the default; could loop `presets_for("esm2")` asserting each maps to `esm2_<tier>_UR50D`.

## Follow-ups (tracked, not in this PR)
The reviewers converge on two cheap, high-value items deliberately deferred to keep this PR additive and avoid touching the in-production `esmfold_runner.py`:
1. Extract `_runners/_linker.py` (pure `keep_indices`) shared by `esmfold_runner.py` + `esm2_runner.py`, with a no-GPU unit test.
2. Add the per-model test scaffolding: `installation/test_venv_esm2.py`, `integration/test_predict_esm2.py` (t6_8M), the `model_esm2` marker, and the `VENVS`/conftest entry.

## Test plan
- [ ] CI / reviewer: `PYTHONPATH=src .venv-ecstasy/bin/python -m pytest -q -m "not installation and not integration and not gpu and not slow"` → all green (58 passed locally).
- [ ] On a GPU node with `.venv-esm2` built (`scripts/install/esm2.sh`): `ecstasy run --dataset val_seq_pair --model esm2 --preset t6_8M --limit 1 --profile` → produces `contact.npz` `(L,L) float16` + `flops.json`.
- [ ] Sanity: predicted `contact.npz` is symmetric, values in `[0,1]`, shape `= lenA+lenB`.

Generated with the SoftNano plugin.
