### PR TITLE
Extend pak_vs_flops plotter: P@K/n, model selection, point injection, styling

### DIFF
--- a/scripts/mentos-perf-benchmarking/plot_pak_vs_flops.py
+++ b/scripts/mentos-perf-benchmarking/plot_pak_vs_flops.py
@@ -32,6 +32,16 @@ from _plotstyle import use_cmu_concrete  # noqa: E402
 
 use_cmu_concrete()  # noqa: E402
 
+# ~2x larger type than matplotlib defaults so the figures read at thumbnail size.
+plt.rcParams.update({
+    "font.size": 20,          # base (was ~10)
+    "axes.titlesize": 26,
+    "axes.labelsize": 22,
+    "xtick.labelsize": 18,
+    "ytick.labelsize": 18,
+    "legend.fontsize": 16,
+})
+
 from ecstasy.config import settings  # noqa: E402
 from ecstasy.models.registry import load_model, model_names  # noqa: E402
 
@@ -59,7 +69,8 @@ def _bootstrap_ci(values: np.ndarray) -> tuple[float, float]:
 
 
 def _collect(dataset: str, partial_cap: int = 0, exclude: set[str] | None = None,
-             tolerance: int = 0) -> list[dict]:
+             tolerance: int = 0, topk_divisor: int = 1,
+             include: set[str] | None = None) -> list[dict]:
     root = settings().runs_root / dataset
     # Iterate every model/variant dir that has FLOPs sidecars (not just finished runs).
     pts = []
@@ -69,6 +80,8 @@ def _collect(dataset: str, partial_cap: int = 0, exclude: set[str] | None = None
     for pred_dir in sorted(root.glob("*/*/predictions")):
         run_dir = pred_dir.parent
         model, variant = run_dir.parts[-2], run_dir.parts[-1]
+        if include and model not in include:
+            continue
         if exclude and model in exclude:
             continue
         if model == "mentos" and variant not in _MENTOS_LABEL:
@@ -85,12 +98,14 @@ def _collect(dataset: str, partial_cap: int = 0, exclude: set[str] | None = None
 
         result = run_dir / "result.json"
         partial = False
-        if tolerance > 0:
-            # Rescore saved predictions with spatial tolerance (no inference, no result.json).
+        if tolerance > 0 or topk_divisor > 1:
+            # Rescore saved predictions (no inference, no result.json) when a spatial
+            # tolerance and/or a non-unit top-K divisor (P@K/n) is requested — neither
+            # is precomputed in result.json.
             if dataset_obj is None:
                 from ecstasy.datasets import load_dataset
                 dataset_obj = load_dataset(dataset)
-            paks = _tolerant_paks(dataset_obj, gt_cache, pred_dir, tolerance)
+            paks = _tolerant_paks(dataset_obj, gt_cache, pred_dir, tolerance, topk_divisor)
         elif result.exists():
             per = json.loads(result.read_text()).get("per_protein", {})
             paks = np.array([v["P@K"] for v in per.values()
@@ -110,13 +125,17 @@ def _collect(dataset: str, partial_cap: int = 0, exclude: set[str] | None = None
 
         flops = np.array(flops)
         lo, hi = _bootstrap_ci(paks)
+        # x-position is the MEDIAN per-protein FLOPs (the distribution is right-skewed in
+        # complex length; median + IQR is a matched, skew-robust summary so the marker sits
+        # centred in its whisker). The horizontal bar is the IQR (p25-p75) spread across
+        # complexes — dispersion, NOT a sampling CI (per-protein FLOPs is deterministic in L).
         pts.append({
             "model": model, "variant": variant,
             "pak": float(paks.mean()), "pak_lo": lo, "pak_hi": hi, "n_pak": int(paks.size),
             "partial": partial,
-            "flops": float(flops.mean()), "n_flops": len(flops),
-            "flops_p10": float(np.percentile(flops, 10)),
-            "flops_p90": float(np.percentile(flops, 90)),
+            "flops": float(np.median(flops)), "n_flops": len(flops),
+            "flops_lo": float(np.percentile(flops, 25)),
+            "flops_hi": float(np.percentile(flops, 75)),
         })
     return pts
 
@@ -146,12 +165,14 @@ from scipy.ndimage import binary_dilation as _binary_dilation  # noqa: E402
 _TOL_ST = np.ones((3, 3), bool)  # Chebyshev neighbourhood for spatial tolerance
 
 
-def _tol_inter_pak(cp_full: np.ndarray, gt: dict, tol: int) -> float | None:
-    """Tolerant inter-chain P@K from a saved (L,L) contact-prob map.
+def _tol_inter_pak(cp_full: np.ndarray, gt: dict, tol: int, divisor: int = 1) -> float | None:
+    """Tolerant inter-chain P@(K/divisor) from a saved (L,L) contact-prob map.
 
-    A top-K predicted inter pair counts as correct if a true inter contact lies
-    within Chebyshev-``tol`` in (chainA-res, chainB-res) space (GT dilated by ``tol``).
-    ``tol=0`` reproduces the exact inter P@K. Returns None when undefined
+    K = #true inter contacts; the metric scores the top ``max(1, round(K/divisor))``
+    predicted inter pairs (divisor=1 → P@K, divisor=5 → P@K/5, the stricter
+    high-confidence precision). A top prediction counts as correct if a true inter
+    contact lies within Chebyshev-``tol`` in (chainA-res, chainB-res) space (GT
+    dilated by ``tol``); ``tol=0`` is exact. Returns None when undefined
     (non-dimer / shape mismatch / no true inter contacts).
     """
     seqs = gt["sequences"]
@@ -166,14 +187,16 @@ def _tol_inter_pak(cp_full: np.ndarray, gt: dict, tol: int) -> float | None:
     K = int((gti & vi).sum())
     if K == 0:
         return None
+    topk = max(1, int(round(K / divisor)))
     dil = (_binary_dilation(gti, _TOL_ST, iterations=tol) if tol > 0 else gti) & vi
-    order = np.argsort(-np.where(vi, cp, -1.0).ravel())[:K]
-    return float(dil.ravel()[order].sum()) / K
+    order = np.argsort(-np.where(vi, cp, -1.0).ravel())[:topk]
+    return float(dil.ravel()[order].sum()) / topk
 
 
-def _tolerant_paks(dataset_obj, gt_cache: dict, pred_dir: Path, tol: int) -> np.ndarray:
-    """Per-protein tolerant inter P@K for one run, scored from saved contact.npz
-    (no inference). GT is cached across runs since it's shared."""
+def _tolerant_paks(dataset_obj, gt_cache: dict, pred_dir: Path, tol: int,
+                   divisor: int = 1) -> np.ndarray:
+    """Per-protein tolerant inter P@(K/divisor) for one run, scored from saved
+    contact.npz (no inference). GT is cached across runs since it's shared."""
     paks = []
     for entry_dir in sorted(pred_dir.glob("*")):
         cpath = entry_dir / "contact.npz"
@@ -190,7 +213,7 @@ def _tolerant_paks(dataset_obj, gt_cache: dict, pred_dir: Path, tol: int) -> np.
             cp_full = np.load(cpath)["probs"].astype(np.float64)
         except Exception:        # noqa: BLE001
             continue
-        v = _tol_inter_pak(cp_full, gt, tol)
+        v = _tol_inter_pak(cp_full, gt, tol, divisor)
         if v is not None:
             paks.append(v)
     return np.array(paks)
@@ -201,8 +224,13 @@ _DISPLAY_NAME = {
     "boltz2": "Boltz2 (with MSAs)",
     "boltz2_nomsa": "Boltz2 (no MSAs)",
     "esmfold": "ESMFold",
-    "mentos": "MENTOS",
+    "mentos": "MENTOS-188M",
+    "mentos_35m": "MENTOS-43M",
+    "mentos_43m": "MENTOS-43M",
     "msa_pairformer": "MSA-Pairformer",
+    "esm2_650m": "ESM2-650M",
+    "esm2_150m": "ESM2-150M",
+    "plmgraph_inter": "PLMGraph-Inter",
     "colabfold": "ColabFold",
 }
 
@@ -217,10 +245,15 @@ def _display_name(model: str) -> str:
 # Other mentos variants (older checkpoints) are skipped in _collect.
 _R0_FULL_MODELS = {"msa_pairformer"}
 _MENTOS_LABEL = {
-    "a5sgd6ul_s90k_r0": "stage1_r0",
-    "a5sgd6ul_s90k": "stage1_r1",
-    "a5sgd6ul_s90k_r3": "stage1_r3",
-    "a5sgd6ul_s90k_r5": "stage1_r5",
+    # 188M was trained with recycling=1, so r0 is off-distribution — show only r1
+    # (its trained operating point). The 43M baseline (trained at r0) comes via --extra-points.
+    "a5sgd6ul_s90k": "r1",
+}
+
+# Friendly dataset titles (the plot title is just the dataset name).
+_DATASET_TITLE = {
+    "val_seq_pair": "V1: Sequence Deleak Dataset",
+    "val_pinder_pair": "V2: Interface Deleak Dataset",
 }
 
 
@@ -258,27 +291,59 @@ def main() -> None:
                          "result.json isn't written yet (PREVIEW of an in-flight sweep)")
     ap.add_argument("--exclude-models", default="",
                     help="comma-separated model names to omit (e.g. an in-flight series)")
+    ap.add_argument("--models", default="",
+                    help="comma-separated whitelist of model names to include (others dropped); "
+                         "empty = all discovered models")
     ap.add_argument("--annotate-r0", action="store_true",
                     help="label each model's r=0 point with its mean P@K and mean T-FLOPs")
     ap.add_argument("--tolerance", type=int, default=0,
                     help="spatial tolerance (residues) for inter P@K: a top-K prediction counts if a "
                          "true inter contact is within this Chebyshev distance. 0 = exact (reads result.json); "
                          ">0 rescores saved predictions (e.g. 2 = ±2 nearby pairs)")
+    ap.add_argument("--topk-divisor", type=int, default=1,
+                    help="score the top K/divisor predictions instead of top K (K = #true inter "
+                         "contacts). 1 = P@K (default); 5 = P@K/5, the stricter high-confidence "
+                         "precision. >1 rescores saved predictions (not precomputed in result.json)")
+    ap.add_argument("--extra-points", default=None,
+                    help="path to a JSON list/dict of precomputed marker dicts (model, variant, pak, "
+                         "pak_lo, pak_hi, flops, flops_lo, flops_hi) to inject — e.g. a model scored "
+                         "outside this script's GT path (subject to --models filtering)")
     args = ap.parse_args()
+    if args.topk_divisor < 1:
+        raise SystemExit("--topk-divisor must be >= 1")
 
     exclude = {m.strip() for m in args.exclude_models.split(",") if m.strip()}
-    pts = _collect(args.dataset, partial_cap=args.partial_cap, exclude=exclude, tolerance=args.tolerance)
+    include = {m.strip() for m in args.models.split(",") if m.strip()}
+    pts = _collect(args.dataset, partial_cap=args.partial_cap, exclude=exclude,
+                   tolerance=args.tolerance, topk_divisor=args.topk_divisor, include=include)
+    metric = "P@K" if args.topk_divisor == 1 else f"P@K/{args.topk_divisor}"
+
+    if args.extra_points:
+        # one or more JSON files (comma-separated). Each is a list of marker dicts, or a
+        # {dataset: marker} map (self-filtering: a per-split map only injects on its split).
+        # Injected points are explicit, so they bypass --models/--exclude-models filtering;
+        # curate one file per plot (or use per-split maps) to control where they appear.
+        for path in (p.strip() for p in args.extra_points.split(",") if p.strip()):
+            extra = json.loads(Path(path).read_text())
+            if isinstance(extra, dict):
+                extra = [extra[args.dataset]] if args.dataset in extra else []
+            for pt in extra:
+                pts.append({**pt, "partial": pt.get("partial", False)})
     if not pts:
         raise SystemExit(f"no runs with flops.json under "
                          f"{settings().runs_root / args.dataset} — run `ecstasy run --profile` first")
     n_partial = sum(p.get("partial", False) for p in pts)
 
     needs_msa = _msa_dependency()
+    # injected (extra-points) markers can declare their own MSA dependency for fill semantics
+    for p in pts:
+        if "needs_msa" in p:
+            needs_msa[p["model"]] = p["needs_msa"]
     models = sorted({p["model"] for p in pts})
     cmap = plt.get_cmap("tab10")
     color = {m: cmap(i % 10) for i, m in enumerate(models)}
 
-    fig, ax = plt.subplots(figsize=(8, 6))
+    fig, ax = plt.subplots(figsize=(11, 8.25))
 
     for m in models:
         mpts = sorted((p for p in pts if p["model"] == m), key=lambda d: d["flops"])
@@ -286,41 +351,40 @@ def main() -> None:
         ys = [p["pak"] for p in mpts]
         # connecting line across this model's presets (the compute->quality curve)
         if len(mpts) > 1:
-            ax.plot(xs, ys, "-", color=color[m], alpha=0.35, lw=1.2, zorder=1)
+            ax.plot(xs, ys, "-", color=color[m], alpha=0.35, lw=2.6, zorder=1)
         filled = needs_msa.get(m, False)
         for p in mpts:
             ax.errorbar(
                 p["flops"], p["pak"],
                 yerr=[[p["pak"] - p["pak_lo"]], [p["pak_hi"] - p["pak"]]],
-                xerr=[[max(0.0, p["flops"] - p["flops_p10"])], [max(0.0, p["flops_p90"] - p["flops"])]],
-                fmt="o", color=color[m], ecolor=color[m], elinewidth=0.8, capsize=2,
-                ms=8, mfc=(color[m] if filled else "white"), mec=color[m], mew=1.5, zorder=3,
+                xerr=[[max(0.0, p["flops"] - p["flops_lo"])], [max(0.0, p["flops_hi"] - p["flops"])]],
+                fmt="o", color=color[m], ecolor=color[m], elinewidth=1.8, capsize=5,
+                ms=16, mfc=(color[m] if filled else "white"), mec=color[m], mew=2.8, zorder=3,
             )
             vlabel = _disp_variant(m, p["variant"])
             if args.annotate_r0 and _is_r0_rep(m, p["variant"]):
                 txt = f"{vlabel}\nP@K {p['pak']:.2f} · {p['flops'] / 1e12:.1f} TFLOP"
                 ax.annotate(txt, (p["flops"], p["pak"]), textcoords="offset points",
-                            xytext=(7, 5), fontsize=6.5, color=color[m], zorder=5,
+                            xytext=(10, 7), fontsize=13, color=color[m], zorder=5,
                             bbox=dict(boxstyle="round,pad=0.18", fc="white",
-                                      ec=color[m], lw=0.6, alpha=0.9))
+                                      ec=color[m], lw=1.0, alpha=0.9))
             else:
                 ax.annotate(vlabel, (p["flops"], p["pak"]), textcoords="offset points",
-                            xytext=(6, 4), fontsize=7, color=color[m])
+                            xytext=(9, 6), fontsize=14, color=color[m])
 
     # Pareto staircase (upper-left envelope): max P@K achievable at <= given FLOPs
     pf = _pareto(pts)
     if len(pf) > 1:
         ax.step([p["flops"] for p in pf], [p["pak"] for p in pf], where="post",
-                color="0.4", ls="--", lw=1.0, zorder=2)
+                color="0.4", ls="--", lw=2.2, zorder=2)
 
-    tol_tag = f"  (±{args.tolerance}-residue tolerance)" if args.tolerance > 0 else ""
+    tol_tag = f" (±{args.tolerance} Residue Tolerance)" if args.tolerance > 0 else ""
     ax.set_xscale("log")
-    ax.set_xlabel("inference FLOPs (true = 2×MACs, contact-dependency subgraph, log scale)")
-    ax.set_ylabel(f"mean inter-chain P@K{tol_tag}  ({args.dataset})")
-    title = "Contact-prediction quality vs. inference compute" + (
-        f"\ninter P@K with ±{args.tolerance}-residue spatial tolerance" if args.tolerance > 0 else "")
+    ax.set_xlabel("Median Inference FLOPs")
+    ax.set_ylabel(f"Mean Inter-chain {metric}{tol_tag}")
+    title = _DATASET_TITLE.get(args.dataset, args.dataset)
     if n_partial:
-        title += f"\n(PREVIEW — {n_partial} run(s) partially scored, in-flight sweep)"
+        title += f"  (PREVIEW — {n_partial} run(s) partially scored)"
     ax.set_title(title)
     ax.grid(True, which="both", ls=":", alpha=0.4)
 
@@ -330,16 +394,13 @@ def main() -> None:
     handles += [
         plt.Line2D([], [], marker="o", ls="", color="0.3", mfc="0.3", label="filled = uses MSA"),
         plt.Line2D([], [], marker="o", ls="", color="0.3", mfc="white", mec="0.3", label="hollow = single-seq"),
-        plt.Line2D([], [], color="0.4", marker="|", markersize=10, mew=1.5, ls="",
-                   label="vertical bar = 95% bootstrap CI of mean P@K"),
-        plt.Line2D([], [], color="0.4", marker="_", markersize=10, mew=1.5, ls="",
-                   label="horizontal bar = 10–90th pct of per-protein FLOPs"),
-        plt.Line2D([], [], ls="--", color="0.4", label="Pareto frontier"),
     ]
-    ax.legend(handles=handles, fontsize=7.5, loc="best")
+    ax.legend(handles=handles, loc="best", markerscale=1.6)
 
     fig.tight_layout()
-    _fname = "pak_vs_flops.png" if args.tolerance == 0 else f"pak_vs_flops_tol{args.tolerance}.png"
+    _suffix = (f"_pakdiv{args.topk_divisor}" if args.topk_divisor > 1 else "") + \
+              (f"_tol{args.tolerance}" if args.tolerance > 0 else "")
+    _fname = f"pak_vs_flops{_suffix}.png"
     out = args.out or str(settings().runs_root / args.dataset / _fname)
     fig.savefig(out, dpi=160)
     fig.savefig(str(Path(out).with_suffix(".pdf")))   # vector copy for the report


### PR DESCRIPTION
## Summary
- Extends the `plot_pak_vs_flops.py` benchmark plotter with the options and presentation
  changes used to produce the FYP structure/sequence P@K-vs-FLOPs figures.
- Adds three reusable, backward-compatible flags (`--topk-divisor`, `--models`,
  `--extra-points`) plus a skew-robust median/IQR FLOPs whisker and larger, more legible styling.

## Changes
- `scripts/mentos-perf-benchmarking/plot_pak_vs_flops.py` (one file, +107/−46):
  - **`--topk-divisor N`** — score top K/N predictions (P@K/N) instead of top K.
  - **`--models`** — comma-separated include whitelist (drives the structure-vs-sequence split).
  - **`--extra-points`** — inject precomputed markers from one or more JSON files (per-split maps
    self-filter), for models scored outside this script's GT path (MENTOS-43M 3-seed average;
    PLMGraph-Inter with ESMFold-inclusive FLOPs). Injected points may declare `needs_msa`.
  - FLOPs marker is now the **median** with an **IQR (p25–p75)** whisker (was mean + p10–p90),
    matching the right-skewed per-protein FLOPs distribution.
  - Legend trimmed to model colours + MSA-fill (bars/Pareto now described in figure captions);
    ~2× larger fonts/markers/line widths and a larger canvas for thumbnail readability.
  - Axis/title relabels + a `_DATASET_TITLE` map (V1/V2) and display names for ESM2 /
    MENTOS-43M / PLMGraph-Inter; MENTOS shown at r1 only (its trained recycle setting).

## Quality gates
- pre-commit: n/a — no `.pre-commit-config.yaml` in the repo.
- pytest: **57 passed** (unit suite `tests/` excluding `tests/integration` and
  `tests/installation`, run via `srun` on an Isambard compute node — job 5214892). The
  integration/installation suites do real GPU model inference / per-venv checks and are
  unrelated to this plotting-script diff; not run.
- thermo-nuclear review: ran — **0 blockers**, 2 should-fix, 2 nits.
- correctness review: ran — 0 blockers, 3 nits.
- API/interface review: ran — 0 blockers, 2 should-fix, 2 nits.
- Ran on: Isambard AI (login41 submit; compute-node job for pytest).

## Convergent action items (no blockers)
All three reviews independently flagged:
1. **Stale `--extra-points` help text** — says "subject to `--models` filtering" but injected
   points intentionally bypass it. (trivial doc fix)
2. **Report-specific defaults baked into a shared script** — `_DATASET_TITLE`, the MENTOS-r1-only
   trim, and the axis relabels change behaviour for all users; suggest `--title` / a
   `--mentos-variants` (or recycle-ladder) flag so the script stays general.
3. **Stale module docstring** — still says "10–90th percentile" / "95% bootstrap CI" whiskers
   after the IQR change and legend trim.

## Thermo-nuclear review
**Overall:** No blocker. File stays ~410 lines (well under 1k); new flags default to prior behaviour; metric/filter additions are clean and symmetric. No spaghetti or file-size problem. Two should-fix items, both about report-specific coupling and stale docs rather than structure.

- **[should-fix] Stale `--extra-points` help text contradicts the implementation.** The argparse help says markers are "subject to `--models` filtering", but the injection and its own comment state injected points bypass `--models`/`--exclude-models`. Fix: update the help string to match.
- **[should-fix] Report-specific config is hardening into a general-purpose plotter.** `_DATASET_TITLE` ("V1: Sequence Deleak Dataset"), the MENTOS-r1-only trim, and the relabels bake one FYP's conventions into a shared script. Code-judo: add a `--title` override (falling back to the dataset name) and make the MENTOS variant set a flag/param, so the "fair-comparison r1-only" decision is a call-site choice, not a global default that silently drops the recycle ladder.
- **[nit] Two ad-hoc post-`_collect` passes over `pts`** (append extra, then override `needs_msa`); could fold into the extra-points loop. Low value.
- **[nit/good] The `flops_p10/p90` → `flops_lo/hi` + median rename and the composable `_suffix` filename are genuine small improvements.** No action.

**Approval bar:** met — no structural regression, no file-size explosion, no spaghetti growth, no unjustified abstraction (the `--extra-points` escape hatch earns its keep: two real models can't traverse the GT path). Recommend addressing the stale help text before merge.

## Reviewer notes — Correctness & logic
**No blockers found.** Core new logic (`topk_divisor`, `--models` include filter, median/IQR, extra-points) is correct.

- **nit — `--extra-points` dict branch** (`extra = [extra[args.dataset]] if args.dataset in extra else []`) assumes each dataset maps to exactly one marker dict, so a per-split map cannot inject multiple points onto a split. Self-filtering itself is correct. Fix: accept a list value too (`v = extra[args.dataset]; extra = v if isinstance(v, list) else [v]`).
- **nit — `--extra-points` JSON load has no error path:** a missing file, bad JSON, or a dict missing required keys (`pak`, `flops`, …) raises an unhandled exception, unlike the defensively-skipped run artifacts. Fix: wrap the load and validate required keys.
- **nit — `needs_msa` override** keys by model name, so an injected point sharing a model name with a discovered run overrides the real one globally. Harmless given current usage (distinct models like `mentos_43m`). Fix: set only when key absent, or document that extra points must use unique model names.

**Verified correct:** `_tol_inter_pak` top-K divisor (`topk = max(1, round(K/divisor))`, `order[:topk]`, `/topk`); `_collect` include-before-exclude membership tests; median/IQR x + p25/p75 with clamped asymmetric xerr; `--topk-divisor >= 1` guard; `tolerance>0 or topk_divisor>1` forces rescore; filename/label keying.

**Stale (pre-existing):** module docstring (lines 12–14) still says "10-90th percentile" whiskers and "95% bootstrap CI" — the IQR change and legend deletion make that text wrong.

## Reviewer notes — API / interface
- **should-fix** — Trimming `_MENTOS_LABEL` to `r1` only is a hard-coded default-behaviour change: every existing invocation now silently drops the MENTOS recycle ladder (r0/r3/r5), with no CLI way to restore it. Promote the recycle whitelist to a flag (e.g. `--mentos-variants …`) defaulting to the full ladder, or a `--mentos-recycle-ladder` toggle.
- **should-fix** — The plot title now comes from a hard-coded FYP map and the axis labels were re-worded for the report ("Median Inference FLOPs" drops the "true = 2×MACs, contact-dependency subgraph, log scale" qualifier); non-V1/V2 datasets get a bare slug title. Move the FYP strings behind a `--title`/`--style report` option and keep the self-documenting axis labels as default.
- **nit** — The 2× font bump and `figsize=(11, 8.25)` are now unconditional, changing every user's output dimensions; consider gating behind `--report`/`--big-fonts` or exposing `--figsize`.
- **nit** — Legend entries explaining the error bars / Pareto line were deleted while the bars still render, and the docstring still advertises "10-90th percentile"; restore/refresh so on-plot semantics stay documented.

**On the new flags:** all three compose correctly and preserve prior behaviour when unused (`--topk-divisor` → `1`/`P@K`, `--models` → `""`/no filter, `--extra-points` → `None`); bare `pak_vs_flops.png` filename unchanged at defaults. The `--extra-points` help-text/behaviour mismatch is the one nit.

## Test plan
- [ ] `python plot_pak_vs_flops.py --dataset val_seq_pair` (no flags) still produces `pak_vs_flops.png` with prior behaviour.
- [ ] `--tolerance 2 --topk-divisor 5` writes `pak_vs_flops_pakdiv5_tol2.png` and scores P@K/5.
- [ ] `--models boltz2,esmfold` restricts to those models; `--extra-points file.json` injects markers regardless of `--models`.
- [ ] Confirm whether the MENTOS-r1-only default and FYP title strings should be gated behind flags before merge (see review notes).

Generated with the SoftNano plugin.
