### PR TITLE
FoldBench PPI dataset + s0xlqidn recycle-ladder plotting

### DIFF
--- a/scripts/mentos-perf-benchmarking/plot_pak_vs_flops.py
+++ b/scripts/mentos-perf-benchmarking/plot_pak_vs_flops.py
@@ -80,12 +80,16 @@ def _collect(dataset: str, partial_cap: int = 0, exclude: set[str] | None = None
     for pred_dir in sorted(root.glob("*/*/predictions")):
         run_dir = pred_dir.parent
         model, variant = run_dir.parts[-2], run_dir.parts[-1]
+        if model == "mentos" and variant not in _MENTOS_LABEL:
+            continue        # show only labelled mentos variants (headline + named sweeps)
+        # Split a named recycle-sweep checkpoint into its own series so its r0..r5 ladder
+        # draws as one clean line instead of tangling with the headline mentos points.
+        if model == "mentos" and variant.startswith("s0xlqidn"):
+            model = "mentos_s0xlqidn"
         if include and model not in include:
             continue
         if exclude and model in exclude:
             continue
-        if model == "mentos" and variant not in _MENTOS_LABEL:
-            continue        # show only the headline step-90000 mentos variants
 
         flops = []
         for fp in pred_dir.glob("*/flops.json"):
@@ -225,6 +229,7 @@ _DISPLAY_NAME = {
     "boltz2_nomsa": "Boltz2 (no MSAs)",
     "esmfold": "ESMFold",
     "mentos": "MENTOS-188M",
+    "mentos_s0xlqidn": "MENTOS-150M (recycle 0→5)",
     "mentos_35m": "MENTOS-43M",
     "mentos_43m": "MENTOS-43M",
     "msa_pairformer": "MSA-Pairformer",
@@ -248,6 +253,8 @@ _MENTOS_LABEL = {
     # 188M was trained with recycling=1, so r0 is off-distribution — show only r1
     # (its trained operating point). The 43M baseline (trained at r0) comes via --extra-points.
     "a5sgd6ul_s90k": "r1",
+    # s0xlqidn = 150M recycle_0to5 run (step-55000), evaluated as a recycle ladder.
+    "s0xlqidn_r0": "r0", "s0xlqidn_r1": "r1", "s0xlqidn_r3": "r3", "s0xlqidn_r5": "r5",
 }
 
 # Friendly dataset titles (the plot title is just the dataset name).
@@ -258,7 +265,7 @@ _DATASET_TITLE = {
 
 
 def _disp_variant(model: str, variant: str) -> str:
-    if model == "mentos":
+    if model.startswith("mentos"):
         return _MENTOS_LABEL.get(variant, variant)
     if model in _R0_FULL_MODELS:
         return "r=0 full"

--- a/src/ecstasy/registry/datasets.yaml
+++ b/src/ecstasy/registry/datasets.yaml
@@ -43,3 +43,23 @@ val_pinder_chain:   # V3 depth-2 walk, fused interface-monomer graph (98)
 val_pinder_pair:    # V4 LPA pair identity — headline               (474)
   <<: *mentos
   index: ${MENTOS_ROOT}/pdb/processed/splits/val_pinder_pair/index.parquet
+
+# FoldBench (BEAM-Labs/FoldBench) low-homology protein-interface test set, processed
+# by mentos/scripts/data_processing/process_foldbench.py into the SAME mentos_square
+# format (64-bin Cβ-Cβ square GT, contact_bin 19 == 8 Å). One shared index.parquet with
+# three split values: protein_protein (PPI), antibody_antigen, and their union. The .pt
+# ids are `<pdb>-assembly1__<c1>_<c2>`, so id[:2] still keys the data/<id[:2]>/ shards.
+_foldbench: &foldbench
+  <<: *mentos
+  index: ${MENTOS_ROOT}/foldbench/processed/index.parquet
+  gt_root: ${MENTOS_ROOT}/foldbench/processed/data
+
+foldbench_pp:       # protein-protein interfaces — PPI headline      (193)
+  <<: *foldbench
+  split: foldbench_pp
+foldbench_abag:     # antibody-antigen interfaces                    (137)
+  <<: *foldbench
+  split: foldbench_abag
+foldbench:          # union of pp + abag                             (330)
+  <<: *foldbench
+  split: foldbench


### PR DESCRIPTION
## What

- **`datasets.yaml`**: register FoldBench (BEAM-Labs) as three ecstasy dataset rows — `foldbench_pp` (193 PPI dimers), `foldbench_abag` (137), `foldbench` (330 union) — pointing at the mentos-processed `mentos_square` GT under `${MENTOS_ROOT}/foldbench`. No `models.yaml` change (boltz2/esmfold `r0`/`r3` presets already existed).
- **`plot_pak_vs_flops.py`**: split a named mentos recycle-sweep checkpoint (`s0xlqidn`) into its own series (`mentos_s0xlqidn`, "MENTOS-150M (recycle 0→5)") so its r0..r5 ladder draws as one clean line instead of tangling with the headline mentos points; registers its variant labels.

## Results produced with this

- **FoldBench PPI** (`foldbench_pp`, 193 dimers, tol=2 inter-chain P@K): boltz2 r0 0.53 / r3 0.56; esmfold r0 0.32 / r3 0.34 (+ FLOPs). → Notion "Sprint 10".
- **s0xlqidn recycle sweep** (MENTOS-150M step-55000) on val_seq_pair + val_pinder_pair at r0/r1/r3/r5 → the two tol=2 P@K-vs-FLOPs ladder plots.

## Notes

- `registry.local.yaml` (the s0xlqidn checkpoint→recycle cache used for the sweep) is gitignored and intentionally not committed.
- Run outputs live under `${DATA_ROOT}/ecstasy/runs/…`; not part of this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)